### PR TITLE
Use ppx_derivers as registry

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, debug, cppo
 "data": -traverse
 
 "src": include
-<src/*.{ml,mli,byte,native}>: package(dynlink ocaml-migrate-parsetree ppx_tools_versioned.metaquot_405 result)
+<src/*.{ml,mli,byte,native}>: package(dynlink ocaml-migrate-parsetree ppx_tools_versioned.metaquot_405 result ppx_derivers)
 <src/ppx_deriving_main.{ml,mli,byte,native}>: package(findlib.dynload)
 <src/ppx_deriving_main.{byte,native}>: predicate(ppx_driver), linkall
 <src_plugins/*.{ml,mli}>: package(ocaml-migrate-parsetree ocaml-migrate-parsetree ppx_tools_versioned.metaquot_405)

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -15,7 +15,7 @@ package "runtime" (
 package "api" (
   version = "%{version}%"
   description = "Plugin API for ppx_deriving"
-  requires = "dynlink compiler-libs.common ppx_tools_versioned result"
+  requires = "dynlink compiler-libs.common ppx_tools_versioned result ppx_derivers"
   archive(byte) = "ppx_deriving.cma"
   archive(native) = "ppx_deriving.cmxa"
   exists_if = "ppx_deriving.cma"

--- a/src/ppx_deriving.mli
+++ b/src/ppx_deriving.mli
@@ -49,12 +49,6 @@ val add_register_hook : (deriver -> unit) -> unit
 (** [derivers ()] returns all currently registered derivers. *)
 val derivers : unit -> deriver list
 
-(** [register_external name] registers [name] as an external deriver that is
-    not interpreted by ppx_deriving. Ppx_deriving will simply ignore [name]
-    when interpreting [[\@\@deriving]] annotations and leave it to be
-    expanded by another rewriter. *)
-val register_external : string -> unit
-
 (** Creating {!deriver} structure. *)
 val create :
   string ->


### PR DESCRIPTION
This implement the sub-request in #130.

Essentially what it does is move the registry into a separate [ppx_derivers package](
https://github.com/diml/ppx_derivers), which has a very simple API:

```ocaml
(** Ppx derivers

    This module holds the various derivers registered by either ppx_deriving or
    ppx_type_conv.
*)

(** Type of a deriver. The concrete constructors are added by
    ppx_type_conv/ppx_deriving. *)
type deriver = ..

(** [register name deriver] registers a new deriver. Raises if [name] is already
    registered. *)
val register : string -> deriver -> unit

(** Lookup a previously registered deriver *)
val lookup : string -> deriver option

(** [derivers ()] returns all currently registered derivers. *)
val derivers : unit -> (string * deriver) list
```

Since this supersede `register_external` which is not yet released, I just removed this function.

This patch makes things simpler for ppx_type_conv, since I can replace the optional dependency on ppx_deriving by a hard dependency on ppx_derivers.
