### PR TITLE
make ppx_deriving 4.1 build under 4.05

### DIFF
--- a/opam
+++ b/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}
+  "cppo_ocamlbuild" {build}
   "ppx_tools"  {>= "4.02.3"}
   "result"
   "ounit"      {test}

--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -327,6 +327,9 @@ let free_vars_in_core_type typ =
       List.map free_in xs |> List.concat
     | { ptyp_desc = Ptyp_alias (x, name) } -> [name] @ free_in x
     | { ptyp_desc = Ptyp_poly (bound, x) } ->
+#if OCAML_VERSION >= (4, 05, 0)
+      let bound = List.map (fun y -> y.txt) bound in
+#endif
       List.filter (fun y -> not (List.mem y bound)) (free_in x)
     | { ptyp_desc = Ptyp_variant (rows, _, _) } ->
       List.map (
@@ -419,6 +422,11 @@ let binop_reduce x a b =
 
 let strong_type_of_type ty =
   let free_vars = free_vars_in_core_type ty in
+#if OCAML_VERSION >= (4, 05, 0)
+  (* give the location of the whole type to the introduced variables *)
+  let loc = { ty.ptyp_loc with loc_ghost = true } in
+  let free_vars = List.map (fun v -> mkloc v loc) free_vars in
+#endif
   Typ.force_poly @@ Typ.poly free_vars ty
 
 type deriver_options =


### PR DESCRIPTION
See #153: this is the start of an attempt to provide a 4.1 maintenance release that supports recent OCaml versions -- as a temporary solution to the current breakage for non-driverized users.

I started by creating a branch [4.1-maintenance](https://github.com/ocaml-ppx/ppx_deriving/commits/4.1-maintenance) on the upstream repo, which contains all the commits that went into 4.2 except for the omp-support changes in #141 -- currently it points exactly to 6b75b9e4804b253945ab61a76ed4af539d6caf90. A first point of potential discussion is whether we should indeed start from all those commits (some of there are small feature requests rather than bugfixes), but I think this is a reasonable basis to start from.

Then I just implemented 4.05-support using ugly preprocessor conditionals. This is the current PR, and it is very simple. I also implemented 4.06-support (which is a bit heavier due, I think, to oversight in the parsetree evolution), which will come as a separate PR.

If there is consensus to merge this PR, this means that users of 4.1-style ppx_deriving will be able to use it under 4.05.0.  
It is an explicit design goal of mine that users of 4.2-style ppx_deriving (in particular jbuilder users) would *not* be affected by a release of a 4.1.1 or 4.1+4.05 maintenance release, but I have not tested for it -- this will have to be tested at the time of (maybe) publishing a 4.1.foo on opam, not from the current PR, but if/when this happens the testing help of jbuilder users will be warmly welcome.

