### PR TITLE
4.06 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: c
-script:
-  - echo "yes" | sudo add-apt-repository ppa:avsm/ocaml42+opam12
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq opam ocaml-native-compilers
-  - export OPAMYES=1
-  - opam init
-  - eval `opam config env`
-  - opam pin add -n ppx_tools git://github.com/alainfrisch/ppx_tools#4.02
-  - opam pin add -n -k path ppx_deriving .
-  - opam install --deps-only -d -t ppx_deriving
-  - opam install -d -t -v ppx_deriving
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex ./.travis-docker.sh
+env:
+  global:
+  - PACKAGE="ppx_deriving"
+  - TESTS="true"
+  matrix:
+  - DISTRO="alpine" OCAML_VERSION="4.05.0"
+  - DISTRO="alpine" OCAML_VERSION="4.04.2"
+  - DISTRO="alpine" OCAML_VERSION="4.04.1"
+  - DISTRO="alpine" OCAML_VERSION="4.04.0"
+  - DISTRO="debian-stable" OCAML_VERSION="4.03.0"
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.02.3"
+  - DISTRO="alpine" OCAML_VERSION="4.06.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - PACKAGE="ppx_deriving"
   - TESTS="true"
   matrix:
+  - DISTRO="alpine" OCAML_VERSION="4.06.0"
   - DISTRO="alpine" OCAML_VERSION="4.05.0"
   - DISTRO="alpine" OCAML_VERSION="4.04.2"
   - DISTRO="alpine" OCAML_VERSION="4.04.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+4.2
+---
+
+  * Add support for OCaml 4.05.0.
+  * Use the `ocaml-migrate-parsetree` library to support multiple
+    versions of OCaml.
+  * Fix comparison order of fields in records (#136).
+  * Silence an `unused rec flag` warning in generated code (#137).
+  * Monomorphize comparison function for builtin types (#115)
+  * Raise an error when `type nonrec` is encountered (#116).
+  * Display an error message when dynamic package loading fails.
+  * Add a `with_path` option to `@@deriving` to skip the module path
+    in generated code (#120).
+
+The homepage for the project has now moved to:
+<https://github.com/ocaml-ppx/ppx_deriving>
+
 4.1
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 Changelog
 =========
 
-4.2
+4.1.5
 ---
 
-  * Add support for OCaml 4.05.0.
-  * Use the `ocaml-migrate-parsetree` library to support multiple
-    versions of OCaml.
+  * Add support for OCaml 4.05.0 and 4.06.0.
   * Fix comparison order of fields in records (#136).
   * Silence an `unused rec flag` warning in generated code (#137).
   * Monomorphize comparison function for builtin types (#115)

--- a/src_plugins/ppx_deriving_enum.cppo.ml
+++ b/src_plugins/ppx_deriving_enum.cppo.ml
@@ -47,7 +47,10 @@ let mappings_of_type type_decl =
             raise_errorf ~loc:ptyp_loc
                          "%s cannot be derived for inherited variant cases" deriver
           | Rtag (name, attrs, true, []) ->
-            map acc mappings attrs { txt = name; loc = ptyp_loc }
+#if OCAML_VERSION < (4, 06, 0)
+            let name = mkloc name ptyp_loc in
+#endif
+            map acc mappings attrs name
           | Rtag _ ->
             raise_errorf ~loc:ptyp_loc
                          "%s can be derived only for argumentless constructors" deriver)

--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -121,11 +121,18 @@ and expr_of_typ quoter typ =
       let cases =
         (fields |> List.map (fun field ->
           let pdup f = ptuple [f "lhs"; f "rhs"] in
+          let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+            Pat.variant label popt
+#else
+            Pat.variant label.txt popt
+#endif
+          in
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr true]
+            Exp.case (pdup (fun _ -> variant label None)) [%expr true]
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
+            Exp.case (pdup (fun var -> variant label (Some (pvar var))))
                      (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))

--- a/src_plugins/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/ppx_deriving_fold.cppo.ml
@@ -63,11 +63,18 @@ let rec expr_of_typ typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) [%expr acc]
+          Exp.case (variant label None) [%expr acc]
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
+          Exp.case (variant label (Some [%pat? x]))
                    [%expr [%e expr_of_typ typ] acc x]
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
           Exp.case [%pat? [%p Pat.type_ tname] as x]

--- a/src_plugins/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/ppx_deriving_iter.cppo.ml
@@ -60,11 +60,18 @@ let rec expr_of_typ typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) [%expr ()]
+          Exp.case (variant label None) [%expr ()]
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
+          Exp.case (variant label (Some [%pat? x]))
                    [%expr [%e expr_of_typ typ] x]
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
           Exp.case [%pat? [%p Pat.type_ tname] as x]

--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -59,12 +59,26 @@ let rec expr_of_typ ?decl typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let pat_variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
+        let exp_variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Exp.variant label popt
+#else
+          Exp.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) (Exp.variant label None)
+          Exp.case (pat_variant label None) (exp_variant label None)
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
-                   (Exp.variant label (Some [%expr [%e expr_of_typ ?decl typ] x]))
+          Exp.case (pat_variant label (Some [%pat? x]))
+                   (exp_variant label (Some [%expr [%e expr_of_typ ?decl typ] x]))
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) -> begin
           match decl with
           | None -> 

--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -127,14 +127,21 @@ and expr_of_typ quoter typ =
       [%expr fun [%p ptuple (pattn `lhs typs)] [%p ptuple (pattn `rhs typs)] ->
         [%e exprn quoter typs |> reduce_compare]]
     | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
+      let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+        Pat.variant label popt
+#else
+        Pat.variant label.txt popt
+#endif
+      in
       let cases =
         fields |> List.map (fun field ->
           let pdup f = ptuple [f "lhs"; f "rhs"] in
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr 0]
+            Exp.case (pdup (fun _ -> variant label None)) [%expr 0]
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
+            Exp.case (pdup (fun var -> variant label (Some (pvar var))))
                      (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))
@@ -147,9 +154,9 @@ and expr_of_typ quoter typ =
         fields |> List.mapi (fun i field ->
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (Pat.variant label None) (int i)
+            Exp.case (variant label None) (int i)
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (Pat.variant label (Some [%pat? _])) (int i)
+            Exp.case (variant label (Some [%pat? _])) (int i)
           | Rinherit { ptyp_desc = Ptyp_constr (tname, []) } ->
             Exp.case (Pat.type_ tname) (int i)
           | _ -> assert false)

--- a/src_plugins/ppx_deriving_show.cppo.ml
+++ b/src_plugins/ppx_deriving_show.cppo.ml
@@ -166,9 +166,15 @@ let rec expr_of_typ quoter typ =
         fields |> List.map (fun field ->
           match field with
           | Rtag (label, _, true (*empty*), []) ->
+#if OCAML_VERSION >= (4, 06, 0)
+            let label = label.txt in
+#endif
             Exp.case (Pat.variant label None)
                      [%expr Format.pp_print_string fmt [%e str ("`" ^ label)]]
           | Rtag (label, _, false, [typ]) ->
+#if OCAML_VERSION >= (4, 06, 0)
+            let label = label.txt in
+#endif
             Exp.case (Pat.variant label (Some [%pat? x]))
                      [%expr Format.fprintf fmt [%e str ("`" ^ label ^ " (@[<hov>")];
                             [%e expr_of_typ typ] x;


### PR DESCRIPTION
This PR sits on top of #154. It adds support for 4.06.0 -- see also #153.

The changes in the drivers are very repetitive and annoying. It comes from the fact that the `label` field (morally) of the `Rtag` parsetree constructor gained a location, but the `label` fields of pattern and expression variant constructors is not located. If I had done this work earlier in the 4.06 release timeline, I would push for changing the parsetree to locate those labels as well -- this is clearly what the code tell us is the right approach for consumers. But I think this is too late for a fix in 4.06, so this will have to wait for 4.07 or never -- and the kludgy conditionals will remain, oh well.