### PR TITLE
4.06 support for ppx_deriving 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - PACKAGE="ppx_deriving"
   - TESTS="true"
   matrix:
+  - DISTRO="alpine" OCAML_VERSION="4.06.0"
   - DISTRO="alpine" OCAML_VERSION="4.05.0"
   - DISTRO="alpine" OCAML_VERSION="4.04.2"
   - DISTRO="alpine" OCAML_VERSION="4.04.1"

--- a/opam
+++ b/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}
+  "cppo_ocamlbuild" {build}
   "ocaml-migrate-parsetree"
   "ppx_derivers"
   "ppx_tools"  {>= "4.02.3"}

--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -325,6 +325,9 @@ let free_vars_in_core_type typ =
       List.map free_in xs |> List.concat
     | { ptyp_desc = Ptyp_alias (x, name) } -> [name] @ free_in x
     | { ptyp_desc = Ptyp_poly (bound, x) } ->
+#if OCAML_VERSION >= (4, 05, 0)
+      let bound = List.map (fun y -> y.txt) bound in
+#endif
       List.filter (fun y -> not (List.mem y bound)) (free_in x)
     | { ptyp_desc = Ptyp_variant (rows, _, _) } ->
       List.map (
@@ -417,6 +420,11 @@ let binop_reduce x a b =
 
 let strong_type_of_type ty =
   let free_vars = free_vars_in_core_type ty in
+#if OCAML_VERSION >= (4, 05, 0)
+  (* give the location of the whole type to the introduced variables *)
+  let loc = { ty.ptyp_loc with loc_ghost = true } in
+  let free_vars = List.map (fun v -> mkloc v loc) free_vars in
+#endif
   Typ.force_poly @@ Typ.poly free_vars ty
 
 type deriver_options =

--- a/src/ppx_deriving.cppo.ml
+++ b/src/ppx_deriving.cppo.ml
@@ -12,21 +12,6 @@ open Parsetree
 open Ast_helper
 open Ast_convenience
 
-#if OCAML_VERSION >= (4, 05, 0)
-module Typ = struct
-  include Typ
-
-  let poly ?(loc= !Ast_helper.default_loc) ?attrs vars ty =
-    let vars = List.map (fun txt -> { Asttypes.loc; txt }) vars in
-    Typ.poly ~loc ?attrs vars ty
-end
-
-let rm_poly_locs =
-  List.map (fun x -> x.Asttypes.txt)
-#else
-let rm_poly_locs x = x
-#endif
-
 type deriver = {
   name : string ;
   core_type : (core_type -> expression) option;
@@ -340,7 +325,6 @@ let free_vars_in_core_type typ =
       List.map free_in xs |> List.concat
     | { ptyp_desc = Ptyp_alias (x, name) } -> [name] @ free_in x
     | { ptyp_desc = Ptyp_poly (bound, x) } ->
-      let bound = rm_poly_locs bound in
       List.filter (fun y -> not (List.mem y bound)) (free_in x)
     | { ptyp_desc = Ptyp_variant (rows, _, _) } ->
       List.map (

--- a/src/ppx_deriving.cppo.mli
+++ b/src/ppx_deriving.cppo.mli
@@ -2,6 +2,12 @@
 
 open Parsetree
 
+#if OCAML_VERSION >= (4, 05, 0)
+type tyvar = string Location.loc
+#else
+type tyvar = string
+#endif
+
 (** {2 Registration} *)
 
 (** A type of deriving plugins.
@@ -223,7 +229,7 @@ val attr_warning: expression -> attribute
 
 (** [free_vars_in_core_type typ] returns unique free variables in [typ] in
     lexical order. *)
-val free_vars_in_core_type : core_type -> string list
+val free_vars_in_core_type : core_type -> tyvar list
 
 (** [remove_pervasives ~deriver typ] removes the leading "Pervasives."
     module name in longidents.
@@ -239,19 +245,19 @@ val fresh_var : string list -> string
 
 (** [fold_left_type_decl fn accum type_] performs a left fold over all type variable
     (i.e. not wildcard) parameters in [type_]. *)
-val fold_left_type_decl : ('a -> string -> 'a) -> 'a -> type_declaration -> 'a
+val fold_left_type_decl : ('a -> tyvar -> 'a) -> 'a -> type_declaration -> 'a
 
 (** [fold_right_type_decl fn accum type_] performs a right fold over all type variable
     (i.e. not wildcard) parameters in [type_]. *)
-val fold_right_type_decl : (string -> 'a -> 'a) -> type_declaration -> 'a -> 'a
+val fold_right_type_decl : (tyvar -> 'a -> 'a) -> type_declaration -> 'a -> 'a
 
 (** [fold_left_type_ext fn accum type_] performs a left fold over all type variable (i.e. not
     wildcard) parameters in [type_]. *)
-val fold_left_type_ext : ('a -> string -> 'a) -> 'a -> type_extension -> 'a
+val fold_left_type_ext : ('a -> tyvar -> 'a) -> 'a -> type_extension -> 'a
 
 (** [fold_right_type_ext fn accum type_] performs a right fold over all type variable (i.e. not
     wildcard) parameters in [type_]. *)
-val fold_right_type_ext : (string -> 'a -> 'a) -> type_extension -> 'a -> 'a
+val fold_right_type_ext : (tyvar -> 'a -> 'a) -> type_extension -> 'a -> 'a
 
 (** [poly_fun_of_type_decl type_ expr] wraps [expr] into [fun poly_N -> ...] for every
     type parameter ['N] present in [type_]. For example, if [type_] refers to

--- a/src_plugins/ppx_deriving_enum.cppo.ml
+++ b/src_plugins/ppx_deriving_enum.cppo.ml
@@ -47,7 +47,10 @@ let mappings_of_type type_decl =
             raise_errorf ~loc:ptyp_loc
                          "%s cannot be derived for inherited variant cases" deriver
           | Rtag (name, attrs, true, []) ->
-            map acc mappings attrs { txt = name; loc = ptyp_loc }
+#if OCAML_VERSION < (4, 06, 0)
+            let name = mkloc name ptyp_loc in
+#endif
+            map acc mappings attrs name
           | Rtag _ ->
             raise_errorf ~loc:ptyp_loc
                          "%s can be derived only for argumentless constructors" deriver)

--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -121,11 +121,18 @@ and expr_of_typ quoter typ =
       let cases =
         (fields |> List.map (fun field ->
           let pdup f = ptuple [f "lhs"; f "rhs"] in
+          let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+            Pat.variant label popt
+#else
+            Pat.variant label.txt popt
+#endif
+          in
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr true]
+            Exp.case (pdup (fun _ -> variant label None)) [%expr true]
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
+            Exp.case (pdup (fun var -> variant label (Some (pvar var))))
                      (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))

--- a/src_plugins/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/ppx_deriving_fold.cppo.ml
@@ -63,11 +63,18 @@ let rec expr_of_typ typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) [%expr acc]
+          Exp.case (variant label None) [%expr acc]
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
+          Exp.case (variant label (Some [%pat? x]))
                    [%expr [%e expr_of_typ typ] acc x]
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
           Exp.case [%pat? [%p Pat.type_ tname] as x]

--- a/src_plugins/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/ppx_deriving_iter.cppo.ml
@@ -60,11 +60,18 @@ let rec expr_of_typ typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) [%expr ()]
+          Exp.case (variant label None) [%expr ()]
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
+          Exp.case (variant label (Some [%pat? x]))
                    [%expr [%e expr_of_typ typ] x]
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
           Exp.case [%pat? [%p Pat.type_ tname] as x]

--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -59,12 +59,26 @@ let rec expr_of_typ ?decl typ =
   | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
     let cases =
       fields |> List.map (fun field ->
+        let pat_variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Pat.variant label popt
+#else
+          Pat.variant label.txt popt
+#endif
+        in
+        let exp_variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+          Exp.variant label popt
+#else
+          Exp.variant label.txt popt
+#endif
+        in
         match field with
         | Rtag (label, _, true (*empty*), []) ->
-          Exp.case (Pat.variant label None) (Exp.variant label None)
+          Exp.case (pat_variant label None) (exp_variant label None)
         | Rtag (label, _, false, [typ]) ->
-          Exp.case (Pat.variant label (Some [%pat? x]))
-                   (Exp.variant label (Some [%expr [%e expr_of_typ ?decl typ] x]))
+          Exp.case (pat_variant label (Some [%pat? x]))
+                   (exp_variant label (Some [%expr [%e expr_of_typ ?decl typ] x]))
         | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) -> begin
           match decl with
           | None -> 

--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -127,14 +127,21 @@ and expr_of_typ quoter typ =
       [%expr fun [%p ptuple (pattn `lhs typs)] [%p ptuple (pattn `rhs typs)] ->
         [%e exprn quoter typs |> reduce_compare]]
     | { ptyp_desc = Ptyp_variant (fields, _, _); ptyp_loc } ->
+      let variant label popt =
+#if OCAML_VERSION < (4, 06, 0)
+        Pat.variant label popt
+#else
+        Pat.variant label.txt popt
+#endif
+      in
       let cases =
         fields |> List.map (fun field ->
           let pdup f = ptuple [f "lhs"; f "rhs"] in
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (pdup (fun _ -> Pat.variant label None)) [%expr 0]
+            Exp.case (pdup (fun _ -> variant label None)) [%expr 0]
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (pdup (fun var -> Pat.variant label (Some (pvar var))))
+            Exp.case (pdup (fun var -> variant label (Some (pvar var))))
                      (app (expr_of_typ typ) [evar "lhs"; evar "rhs"])
           | Rinherit ({ ptyp_desc = Ptyp_constr (tname, _) } as typ) ->
             Exp.case (pdup (fun var -> Pat.alias (Pat.type_ tname) (mknoloc var)))
@@ -147,9 +154,9 @@ and expr_of_typ quoter typ =
         fields |> List.mapi (fun i field ->
           match field with
           | Rtag (label, _, true (*empty*), []) ->
-            Exp.case (Pat.variant label None) (int i)
+            Exp.case (variant label None) (int i)
           | Rtag (label, _, false, [typ]) ->
-            Exp.case (Pat.variant label (Some [%pat? _])) (int i)
+            Exp.case (variant label (Some [%pat? _])) (int i)
           | Rinherit { ptyp_desc = Ptyp_constr (tname, []) } ->
             Exp.case (Pat.type_ tname) (int i)
           | _ -> assert false)

--- a/src_plugins/ppx_deriving_show.cppo.ml
+++ b/src_plugins/ppx_deriving_show.cppo.ml
@@ -166,9 +166,15 @@ let rec expr_of_typ quoter typ =
         fields |> List.map (fun field ->
           match field with
           | Rtag (label, _, true (*empty*), []) ->
+#if OCAML_VERSION >= (4, 06, 0)
+            let label = label.txt in
+#endif
             Exp.case (Pat.variant label None)
                      [%expr Format.pp_print_string fmt [%e str ("`" ^ label)]]
           | Rtag (label, _, false, [typ]) ->
+#if OCAML_VERSION >= (4, 06, 0)
+            let label = label.txt in
+#endif
             Exp.case (Pat.variant label (Some [%pat? x]))
                      [%expr Format.fprintf fmt [%e str ("`" ^ label ^ " (@[<hov>")];
                             [%e expr_of_typ typ] x;


### PR DESCRIPTION
This is a cherry-pick of @gasche changes from #155 to make the driverized version in the master branch work on OCaml 4.06.

This fixes ppx_deriving for jbuilder users when using ppx_deriving with other driverized ppxs. The error message was `Error: ppx_type_conv: 'show' is not a supported type type-conv generator`.