### PR TITLE
Restrict type for [%eq: unit] and [%ord: unit]

### DIFF
--- a/src_plugins/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/ppx_deriving_eq.cppo.ml
@@ -71,7 +71,7 @@ and expr_of_typ quoter typ =
       let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
       begin match builtin, typ with
       | true, [%type: unit] ->
-        [%expr fun _ _ -> true]
+        [%expr fun (_:unit) (_:unit) -> true]
       | true, ([%type: int] | [%type: int32] | [%type: Int32.t] |
                [%type: int64] | [%type: Int64.t] | [%type: nativeint] |
                [%type: Nativeint.t] | [%type: float] | [%type: bool] |

--- a/src_plugins/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ppx_deriving_ord.cppo.ml
@@ -70,8 +70,10 @@ and expr_of_typ quoter typ =
     | { ptyp_desc = Ptyp_constr _ } ->
       let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
       begin match builtin, typ with
-      | true, ([%type: _] | [%type: unit]) ->
+      | true, [%type: _] ->
         [%expr fun _ _ -> 0]
+      | true, [%type: unit] ->
+        [%expr fun (_:unit) (_:unit) -> 0]
       | true, ([%type: int] | [%type: int32] | [%type: Int32.t]
               | [%type: int64] | [%type: Int64.t] | [%type: nativeint]
               | [%type: Nativeint.t] | [%type: float] | [%type: bool]


### PR DESCRIPTION
Hi!

Adding these type annotations is necessary to prevent the following cases:

    # [%eq: unit] 2 3;;
    - : bool = true

and

    # [%ord: unit] 2 3;;
    - : int = 0

See #115 for a similar, solved, problem.

Thanks!