### PR TITLE
map plugin: add a type annotation to avoid warning 41

### DIFF
--- a/src_plugins/ppx_deriving_map.cppo.ml
+++ b/src_plugins/ppx_deriving_map.cppo.ml
@@ -127,7 +127,8 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
           name, [%expr [%e expr_of_typ ~decl:type_decl pld_type]
                        [%e Exp.field (evar "x") (mknoloc (Lident name))]])
       in
-      [%expr fun x -> [%e record fields]]
+      let annot_typ = Ppx_deriving.core_type_of_type_decl type_decl in
+      [%expr fun (x:[%t annot_typ]) -> [%e record fields]]
     | Ptype_abstract, None ->
       raise_errorf ~loc "%s cannot be derived for fully abstract types" deriver
     | Ptype_open, _        ->


### PR DESCRIPTION
Hi!

In some cases like the following, the generated code can emit instances of warning 41.

```ocaml
type 'a t1 = { x : 'a ; y1 : int } [@@deriving map]
type 'a t2 = { x : 'a ; y2 : int } [@@deriving map]
```

An alternative would be to add a constraint to the generated `map` function, but it does not seem to play well with polymorphism.

I also removed an intermediate `List.concat` since the list is always a singleton.

Let me know what you think.

Thanks!