### PR TITLE
Suppress warning 32 for show

### DIFF
--- a/src_plugins/ppx_deriving_show.cppo.ml
+++ b/src_plugins/ppx_deriving_show.cppo.ml
@@ -316,9 +316,10 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "pp") type_decl) in
   let show_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "show") type_decl) in
+  let no_warn_32 = Ppx_deriving.attr_warning [%expr "-32"] in
   [Vb.mk (Pat.constraint_ pp_var pp_type)
          (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter));
-   Vb.mk (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
+   Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
 
 let () =
   Ppx_deriving.(register (create deriver


### PR DESCRIPTION
As reported in #171, using `[@@deriving show]` can trigger unwanted unused value warnings.

This PR adds a `[@@warning "-32"]` attribute to the generated `let show = ...` structure item to prevent such warnings.

I might look into a `[@@deriving pp]` alternate solution if I get some time to do so but this seemed like a simpler and faster first step.

This is my first PR on `ppx_deriving` so I might have gotten a few things wrong, especially around the `loc` to use for the generated code.

I tested this on our codebase at Cryptosense and it seems to do the job!

I guess it might be a good idea to expose a way to disable this feature since that makes it impossible for `pp` and `show` to trigger such a warning even when it would be relevant.

Let me know what you think!