### PR TITLE
4.02 nit in the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build
 pkg/META
 src_test/_tags
 .merlin
+_opam

--- a/src_test/map/test_deriving_map.cppo.ml
+++ b/src_test/map/test_deriving_map.cppo.ml
@@ -100,7 +100,7 @@ let test_var2 ctxt =
   assert_equal ~printer:(show_var2 fmt_int) (A2 5) (map_var2 int_of_float (A2 5.))
 
 let test_var3 ctxt =
-  let show,map = show_var3 fmt_int fmt_str, map_var3 ((+)1) String.uppercase_ascii in
+  let show,map = show_var3 fmt_int fmt_str, map_var3 ((+)1) String.uppercase in
   assert_equal ~printer:show (A3 2) (map (A3 1));
   assert_equal ~printer:show (B3 false) (map (B3 false));
   assert_equal ~printer:show (C3("ABC", A3 3)) (map (C3("abc", A3 2)));
@@ -124,7 +124,7 @@ let test_record2 ctxt =
 
 let test_record3 ctxt =
   assert_equal ~printer:(show_record3 fmt_int fmt_str)
-    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase_ascii {a3=4;b3=false;c3="abc"});
+    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase {a3=4;b3=false;c3="abc"});
   assert_equal ~printer:(show_record3 fmt_int fmt_flt)
     {a3=97;b3=false;c3=4.} (map_record3 Char.code float_of_int {a3='a';b3=false;c3=4})
 

--- a/src_test/map/test_deriving_map.cppo.ml
+++ b/src_test/map/test_deriving_map.cppo.ml
@@ -100,7 +100,7 @@ let test_var2 ctxt =
   assert_equal ~printer:(show_var2 fmt_int) (A2 5) (map_var2 int_of_float (A2 5.))
 
 let test_var3 ctxt =
-  let show,map = show_var3 fmt_int fmt_str, map_var3 ((+)1) String.uppercase in
+  let show,map = show_var3 fmt_int fmt_str, map_var3 ((+)1) String.uppercase [@warning "-3"] in
   assert_equal ~printer:show (A3 2) (map (A3 1));
   assert_equal ~printer:show (B3 false) (map (B3 false));
   assert_equal ~printer:show (C3("ABC", A3 3)) (map (C3("abc", A3 2)));
@@ -123,10 +123,12 @@ let test_record2 ctxt =
   assert_equal ~printer:(show_record2 fmt_int) {a2=5;b2=0} (map_record2 int_of_float {a2=5.;b2=0})
 
 let test_record3 ctxt =
-  assert_equal ~printer:(show_record3 fmt_int fmt_str)
-    {a3=5;b3=false;c3="ABC"} (map_record3 ((+)1) String.uppercase {a3=4;b3=false;c3="abc"});
-  assert_equal ~printer:(show_record3 fmt_int fmt_flt)
-    {a3=97;b3=false;c3=4.} (map_record3 Char.code float_of_int {a3='a';b3=false;c3=4})
+  let show,map = show_record3 fmt_int fmt_str,
+                 map_record3 ((+)1) String.uppercase [@warning "-3"]
+  in
+  assert_equal ~printer:show {a3=5;b3=false;c3="ABC"} (map {a3=4;b3=false;c3="abc"});
+  let show,map = show_record3 fmt_int fmt_flt, map_record3 Char.code float_of_int in
+  assert_equal ~printer:show {a3=97;b3=false;c3=4.} (map {a3='a';b3=false;c3=4})
 
 let test_pvar3 ctxt =
   let show,map = show_pvar3 fmt_str fmt_int fmt_int,


### PR DESCRIPTION
A couple ppx_deriving.map tests used `String.uppercase_ascii`. This was the only thing preventing the library from building and passing tests on 4.02.3; and it looked like, at their callsites, reliable behaviour w.r.t. higher-plane bytes wasn't important to the semantics of the test.

Let me know if there's a better solution!