### PR TITLE
Support empty Location.input_name in input ast

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -587,6 +587,7 @@ let derive_module_type_decl path module_type_decl pstr_loc item fn =
 
 let module_from_input_name () =
   match !Location.input_name with
+  | ""
   | "//toplevel//" -> []
   | filename ->
     let capitalize =


### PR DESCRIPTION
Fixes jaredly/reason-language-server#297

When using reason-language-server in a dune project, I started seeing the following error bubble up from the running language server instance when I introduced `ppx_deriving.std`:

```
Fatal error: exception (Invalid_argument Filename.chop_suffix)
Raised at file "parsing/ast_mapper.ml", line 826, characters 12-21
Called from file "parsing/ast_mapper.ml", line 843, characters 38-58
Called from file "parsing/ast_mapper.ml", line 878, characters 14-27
Called from file "src/driver.ml", line 1266, characters 6-39
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Re-raised at file "parsing/location.ml", line 465, characters 14-25
Called from file "parsing/location.ml" (inlined), line 470, characters 31-61
Called from file "src/driver.ml", line 1271, characters 4-59
Called from file ".ppx/2a2600f2bea99fd7f9b28cf9261397f6/ppx.ml", line 1, characters 9-36
File "", line 1:
Error: Error while running external preprocessor
Command line: /Users/ryanartecona/code/axl/_build/default/.ppx/2a2600f2bea99fd7f9b28cf9261397f6/ppx.exe --as-ppx --cookie 'library-name="axl"' '/var/folders/6y/6ml47_vs4rgbh77xcb2vtzch0000gn/T/camlppx1912f1' '/var/folders/6y/6ml47_vs4rgbh77xcb2vtzch0000gn/T/camlppx90145c'
```

It wasn't straightforward to get here (dune collapsing multiple ppxes in use but not telling me which one an exception was raised from was annoying), but I eventually traced it to this `module_from_input_name` function in `ppx_deriving`.

The `reason-language-server` server uses `refmt` and `ocamlc` to do incremental error checking between saves while the user is working in a file. It turns out, when `reason-language-server` grabs the contents of an editor buffer, it first passes it straight to `refmt` (presumably to surface syntax errors first) which outputs a binary format AST, and next that AST file is passed to `ocamlc`. With a ppx like `ppx_deriving` in use, that `ocamlc` invocation will have a big hairy `-ppx '...'` argument, and it appears the ppx will be given whatever that prior `refmt` step output. In this case, since `refmt` was given buffer contents via stdin, it doesn't have a file name to put in its binary AST output, so the ppx sees a `Location.input_name` of `""`.

Adding this one match case for an empty string was the simplest thing that fixed my specific error. I don't know how sensitive the rest of `ppx_deriving` internals are to `module_from_input_name` generating something meaningful, but if it's not critical, it may be better to have an `Invalid_argument _ -> []` exception handler in case that `(basename (chop_suffix ...))` bit chokes on other nonsense. Unsure.