### PR TITLE
Add `Result.result` to the .mli file

### DIFF
--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -89,6 +89,11 @@ module Result : sig
   type ('a, 'b) t = ('a, 'b) Result.result =
     | Ok of 'a
     | Error of 'b
+    
+  (* we also expose Result.result for backward-compatibility *)
+  type ('a, 'b) result = ('a, 'b) Result.result =
+    | Ok of 'a
+    | Error of 'b
 end
 
 (** {3 Formatting} *)


### PR DESCRIPTION
The comment in the `.ml` file mentions this is done for backwards compatibility but it wasn't actually exposed in the interface.