### PR TITLE
Fix handling of attributes of record fields in inline records

### DIFF
--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -54,8 +54,14 @@ let rec exprn quoter typs =
     app (expr_of_typ quoter typ) [evar (argn `lhs i); evar (argn `rhs i)])
 
 and exprl quoter typs =
-  typs |> List.map (fun { pld_name = { txt = n }; pld_type = typ } ->
-    app (expr_of_typ quoter typ) [evar (argl `lhs n); evar (argl `rhs n)])
+  typs |> List.map (fun ({ pld_name = { txt = n }; pld_loc; _ } as pld) ->
+    with_default_loc pld_loc @@ fun () ->
+    app (expr_of_label_decl quoter pld)
+      [evar (argl `lhs n); evar (argl `rhs n)])
+
+and expr_of_label_decl quoter { pld_type; pld_attributes } =
+  let attrs = pld_type.ptyp_attributes @ pld_attributes in
+  expr_of_typ quoter { pld_type with ptyp_attributes = attrs }
 
 and expr_of_typ quoter typ =
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
@@ -176,13 +182,12 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       [%expr fun lhs rhs -> [%e Exp.match_ [%expr lhs, rhs] cases]]
     | Ptype_record labels, _ ->
       let exprs =
-        labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes; pld_loc } ->
+        labels |> List.map (fun ({ pld_loc; pld_name = { txt = name }; _ } as pld) ->
           with_default_loc pld_loc @@ fun () ->
           (* combine attributes of type and label *)
-          let attrs =  pld_type.ptyp_attributes @ pld_attributes in
-          let pld_type = {pld_type with ptyp_attributes=attrs} in
           let field obj = Exp.field obj (mknoloc (Lident name)) in
-          app (expr_of_typ quoter pld_type) [field (evar "lhs"); field (evar "rhs")])
+          app (expr_of_label_decl quoter pld)
+            [field (evar "lhs"); field (evar "rhs")])
       in
       [%expr fun lhs rhs -> [%e exprs |> Ppx_deriving.(fold_exprs (binop_reduce [%expr (&&)]))]]
     | Ptype_abstract, None ->

--- a/src_test/show/test_deriving_show.cppo.ml
+++ b/src_test/show/test_deriving_show.cppo.ml
@@ -85,6 +85,16 @@ let test_record ctxt =
   assert_equal ~printer "{ Test_deriving_show.f1 = 1; f2 = \"foo\"; f3 = <opaque> }"
                         (show_re { f1 = 1; f2 = "foo"; f3 = 1.0 })
 
+type variant = Foo of {
+  f1 : int;
+  f2 : string;
+  f3 : float [@opaque];
+} [@@deriving show]
+let test_variant_record ctxt =
+  assert_equal ~printer
+    "Test_deriving_show.Foo {f1 = 1; f2 = \"foo\"; f3 = <opaque>}"
+    (show_variant (Foo { f1 = 1; f2 = "foo"; f3 = 1.0 }))
+
 
 module M : sig
   type t = A [@@deriving show]
@@ -247,6 +257,7 @@ let suite = "Test deriving(show)" >::: [
     "test_poly"            >:: test_poly;
     "test_poly_inherit"    >:: test_poly_inherit;
     "test_record"          >:: test_record;
+    "test_variant_record"  >:: test_variant_record;
     "test_abstr"           >:: test_abstr;
     "test_custom"          >:: test_custom;
     "test_parametric"      >:: test_parametric;


### PR DESCRIPTION
fixes #194

This bug is likely to also affect out-of-tree plugins, which should
probably be notified -- attribute propagation is currently not
centralized and has to be done by each plugin.