### PR TITLE
Result: ensure Result.t and Result.result are exposed under both 4.08 and earlier versions

### DIFF
--- a/src/runtime/ppx_deriving_runtime.cppo.ml
+++ b/src/runtime/ppx_deriving_runtime.cppo.ml
@@ -23,6 +23,16 @@ type nonrec bytes = bytes
 module Stdlib = Stdlib
 
 include Stdlib
+
+module Result = struct
+  type ('a, 'b) t = ('a, 'b) Result.t =
+    | Ok of 'a
+    | Error of 'b
+
+  type ('a, 'b) result = ('a, 'b) Result.t =
+    | Ok of 'a
+    | Error of 'b
+end
 #else
 module Pervasives = Pervasives
 module Stdlib = Pervasives

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -33,6 +33,18 @@ include (module type of Stdlib with
   type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Stdlib.format4 and
   type ('a, 'b, 'c) format = ('a, 'b, 'c) Stdlib.format
 )
+
+module Result : sig
+  type ('a, 'b) t = ('a, 'b) Result.t =
+    | Ok of 'a
+    | Error of 'b
+
+  (* we also expose Result.result for backward-compatibility
+     with the Result package! *)
+  type ('a, 'b) result = ('a, 'b) Result.t =
+    | Ok of 'a
+    | Error of 'b
+end
 #else
 module Pervasives : (module type of Pervasives with
   type fpclass = Pervasives.fpclass and
@@ -89,7 +101,7 @@ module Result : sig
   type ('a, 'b) t = ('a, 'b) Result.result =
     | Ok of 'a
     | Error of 'b
-    
+
   (* we also expose Result.result for backward-compatibility *)
   type ('a, 'b) result = ('a, 'b) Result.result =
     | Ok of 'a


### PR DESCRIPTION
cc #197 @anmonteiro . Would that change avoid any Result-related code change in 
https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/99 ?

My goal is not only to fix ppx_deriving_yojson or make our life easier, but to ensure that we limit breaking other plugins as much as possible. For that reason, even the partial workaround that you used in https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/99/commits/3e16cd22d6c410c7d5362ed68334edda742094e9 is not fully satisfying.