### PR TITLE
fix an ordering bug in free_vars_in_core_type

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -400,7 +400,7 @@ let free_vars_in_core_type typ =
   in
   let uniq lst =
     let module StringSet = Set.Make(String) in
-    let add name (names, txts) =
+    let add (rev_names, txts) name =
       let txt =
 #if OCAML_VERSION >= (4, 05, 0)
         name.txt
@@ -409,9 +409,9 @@ let free_vars_in_core_type typ =
 #endif
       in
       if StringSet.mem txt txts
-      then (names, txts)
-      else (name :: names, StringSet.add txt txts)
-    in fst (List.fold_right add lst ([], StringSet.empty))
+      then (rev_names, txts)
+      else (name :: rev_names, StringSet.add txt txts)
+    in List.rev (fst (List.fold_left add ([], StringSet.empty) lst))
   in free_in typ |> uniq
 
 let var_name_of_int i =

--- a/src_test/api/dune
+++ b/src_test/api/dune
@@ -1,0 +1,9 @@
+(rule
+ (deps test_api.cppo.ml)
+ (targets test_api.ml)
+ (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
+
+(test
+ (name test_api)
+ (libraries oUnit compiler-libs.common ppx_deriving.api)
+ (preprocess (action (run ppxfind -legacy ppx_tools.metaquot --as-pp %{input-file}))))

--- a/src_test/api/test_api.cppo.ml
+++ b/src_test/api/test_api.cppo.ml
@@ -1,0 +1,30 @@
+open Parsetree
+open OUnit2
+
+let string_of_tyvar tyvar =
+#if OCAML_VERSION >= (4, 05, 0)
+  tyvar.Location.txt
+#else
+  tyvar
+#endif
+
+let test_free_vars ctxt =
+  let free_vars = Ppx_deriving.free_vars_in_core_type in
+  let (!!) li = List.map string_of_tyvar li in
+  let printer li =
+    List.map (Printf.sprintf "%S") li |> String.concat ", " in
+  assert_equal ~printer
+    !!(free_vars [%type: int]) [];
+  assert_equal ~printer
+    !!(free_vars [%type: 'a option]) ["a"];
+  assert_equal ~printer
+    !!(free_vars [%type: ('a, 'b) result]) ["a"; "b"];
+  assert_equal ~printer
+    !!(free_vars [%type: ('a, 'b * 'a) result]) ["a"; "b"];
+  ()
+
+let suite = "Test API" >::: [
+    "test_free_vars" >:: test_free_vars;
+  ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
The variables listed in free_vars_in_core_type should occur in lexical
order of appearance, left-to-right: for example with `('b * 'a)
option`, we want to see `'b` before `'a`, so the resulting list is [b; a].

There was a bug in the ordering in the case where a variable is
repeated (`('b * 'a) option * 'b`); in that case it would use for
a variable the ordering of the rightmost occurrence, instead of the
leftmost occurrence, to determine placement. It would thus return [a;
b], while we expect [b; a] in this case -- this is what is returned
with this patch.