### PR TITLE
Gate inline-records-with-attributes test to >=4.03

### DIFF
--- a/src_test/show/test_deriving_show.cppo.ml
+++ b/src_test/show/test_deriving_show.cppo.ml
@@ -85,6 +85,7 @@ let test_record ctxt =
   assert_equal ~printer "{ Test_deriving_show.f1 = 1; f2 = \"foo\"; f3 = <opaque> }"
                         (show_re { f1 = 1; f2 = "foo"; f3 = 1.0 })
 
+#if OCAML_VERSION >= (4, 03, 0)
 type variant = Foo of {
   f1 : int;
   f2 : string;
@@ -94,6 +95,7 @@ let test_variant_record ctxt =
   assert_equal ~printer
     "Test_deriving_show.Foo {f1 = 1; f2 = \"foo\"; f3 = <opaque>}"
     (show_variant (Foo { f1 = 1; f2 = "foo"; f3 = 1.0 }))
+#endif
 
 
 module M : sig
@@ -257,7 +259,9 @@ let suite = "Test deriving(show)" >::: [
     "test_poly"            >:: test_poly;
     "test_poly_inherit"    >:: test_poly_inherit;
     "test_record"          >:: test_record;
+#if OCAML_VERSION >= (4, 03, 0)
     "test_variant_record"  >:: test_variant_record;
+#endif
     "test_abstr"           >:: test_abstr;
     "test_custom"          >:: test_custom;
     "test_parametric"      >:: test_parametric;


### PR DESCRIPTION
Fixing #199 on 4.02.3. Somebody should sanity-check this; it was just the simplest way for me to get the tests passing. (hi! 🙋‍♀️ yep, that's me, still over here being an annoyance 🤣)

Presumably, whatever feature he's adding support for is unavailable on the 4.02-series? Nonetheless, being present in the tests-file at all breaks them on 4.02.3 for me:

```
    ocamlopt .ppx/20e3ffc6dc013e448ad889e12acbb4d5/ppx.exe
         ppx src_test/map/test_deriving_map.pp.ml
    ocamlopt src_test/deriving/test_ppx_deriving.exe
    ocamldep src_test/map/.test_deriving_map.eobjs/test_deriving_map.pp.ml.d
    ocamlopt .ppx/4c4b0dc849c26ef889ee6f55cb3a0672/ppx.exe
      ocamlc src_test/map/.test_deriving_map.eobjs/byte/test_deriving_map.{cmi,cmo,cmt}
         ppx src_test/show/test_deriving_show.pp.ml (exit 1)
(cd _build/default && .ppx/4c4b0dc849c26ef889ee6f55cb3a0672/ppx.exe -o src_test/show/test_deriving_show.pp.ml --impl src_test/show/test_deriving_show.ml --dump-ast)
File "test_deriving_show.cppo.ml", line 88, characters 22-23:
Error: Syntax error
```

Let me know if this is a bad idea somehow! :heart: