### PR TITLE
add back 4.02 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   matrix:
+  - OCAML_VERSION=4.02 # we require >=4.02.2 but this picks 4.02.3
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05


### PR DESCRIPTION
We require >=4.02.2, but in fact OCAML_VERSION=4.02 automatically
picks 4.02.3 nowadays, so CI on 4.02 should work correctly.

(CI testing for this PR should break now and work once #204 is merged.)