### PR TITLE
Promote preprocessed runtime files into source-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ pkg/META
 src_test/_tags
 .merlin
 _opam
+
+# dune-promoted cppo output
+src/runtime/ppx_deriving_runtime.ml
+src/runtime/ppx_deriving_runtime.mli

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.0)
+(lang dune 1.10)
 
 (name ppx_deriving)

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune"     {build >= "1.6.3"}
+  "dune"     {build >= "1.10.0"}
   "cppo"     {build}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree"

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -8,9 +8,11 @@
 (rule
  (deps ppx_deriving_runtime.cppo.ml)
  (targets ppx_deriving_runtime.ml)
+ (mode (promote (until-clean)))
  (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
 
 (rule
  (deps ppx_deriving_runtime.cppo.mli)
  (targets ppx_deriving_runtime.mli)
+ (mode (promote (until-clean)))
  (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))


### PR DESCRIPTION
This is primarily to make my life easier over in BuckleScript land: BuckleScript's preprocessor-language is [incompatible with cppo's][bs-3820]; and thus it's easiest for me to avoid the issue entirely and just let Dune do the build.

Unfortunately, BuckleScript and dune *also* disagree about build-tree locations (`_build/` for the latter, `lib/bs/` for the former, inexplicably); so BuckleScript doesn't see the cppo-processed output that dune produces during the build. To clear that up, I'm tweaking the Dune build to [write the preprocessed source back into the source-tree][modes-promote].

Notably, this approach *doesn't* require Dune 1.10 or above; but there's a new syntax (`promote-until-clean` became `(promote (until-clean))`); and the documentation suggests to future-proof your config by avoiding the former. I'll leave it up to you whether you want to pull in the Dune-version-bump; if not, just switch to `promote-until-clean`.

(See [previous discussion on #193](https://github.com/ocaml-ppx/ppx_deriving/pull/193#pullrequestreview-285410998)!)

[bs-3820]: <https://github.com/BuckleScript/bucklescript/issues/3820>
[modes-promote]: <https://dune.readthedocs.io/en/stable/dune-files.html?highlight=source_tree#modes>