### PR TITLE
Only convert needed parts of the AST instead of converting mapper

### DIFF
--- a/src/ppx_deriving_main.cppo.ml
+++ b/src/ppx_deriving_main.cppo.ml
@@ -94,6 +94,7 @@ let mapper argv =
               | _ -> assert false) |>
             add_plugins;
             mapper.Current_ast.Ast_mapper.structure mapper tl
+        | exception Migrate_parsetree.Def.Migration_error ->
         | _ -> omp_mapper.Current_ast.Ast_mapper.structure mapper s in
   { omp_mapper with Current_ast.Ast_mapper.structure }
 

--- a/src/ppx_deriving_main.cppo.ml
+++ b/src/ppx_deriving_main.cppo.ml
@@ -91,7 +91,7 @@ let mapper argv =
               | _ -> assert false) |>
             add_plugins;
             mapper.Current_ast.Ast_mapper.structure mapper tl
-        | exception Migrate_parsetree.Def.Migration_error ->
+        | exception Migrate_parsetree.Def.Migration_error _ ->
         | _ -> omp_mapper.Current_ast.Ast_mapper.structure mapper s in
   { omp_mapper with Current_ast.Ast_mapper.structure }
 

--- a/src/ppx_deriving_main.cppo.ml
+++ b/src/ppx_deriving_main.cppo.ml
@@ -46,10 +46,12 @@ let load_plugin ?loc plugin =
     dynlink ?loc plugin
 
 let get_plugins () =
-  match Ast_mapper.get_cookie "ppx_deriving" with
+  match Ast_mapper.get_cookie "ppx_deriving"
+        |> Option.map From_current.copy_expression
+  with
   | Some { pexp_desc = Pexp_tuple exprs } ->
     exprs |> List.map (fun expr ->
-      match From_current.copy_expression expr with
+      match expr with
       | { pexp_desc = Pexp_constant (Pconst_string (file, None)) } -> file
       | _ -> assert false)
   | Some _ -> assert false

--- a/src/ppx_deriving_main.cppo.ml
+++ b/src/ppx_deriving_main.cppo.ml
@@ -70,9 +70,6 @@ let add_plugins plugins =
 let mapper argv =
   get_plugins () |> List.iter load_plugin;
   add_plugins argv;
-  let module Convert =
-    Migrate_parsetree.Convert (Migrate_parsetree.OCaml_current)
-      (Migrate_parsetree.OCaml_408) in
   let copy_structure_item item =
     match From_current.copy_structure [item] with
     | [item] -> item


### PR DESCRIPTION
This fixes the segmentation fault reported by kit-ty-kate:
https://github.com/ocaml-ppx/ppx_deriving/pull/210#issuecomment-632136159

I don't know where this segmentation fault precisely occurred, but I suppose that converting the mapper makes Migrate_parsetree make a lot of conversion between each sub-tree of the AST. The new approach is a bit more verbose but conceptually simpler and should be more efficient.