### PR TITLE
Use "include module type of struct include" to get all equalities

### DIFF
--- a/src/runtime/ppx_deriving_runtime.cppo.ml
+++ b/src/runtime/ppx_deriving_runtime.cppo.ml
@@ -14,7 +14,7 @@ type nonrec int64 = int64
 type nonrec 'a lazy_t = 'a lazy_t
 type nonrec bytes = bytes
 
-#if OCAML_VERSION >= (4, 08, 0)
+#if OCAML_VERSION >= (4, 07, 0)
 (* We require 4.08 while 4.07 already has a Stdlib module.
    In 4.07, the type equalities on Stdlib.Pervasives
    are not strong enough for the 'include Stdlib'
@@ -25,11 +25,11 @@ module Stdlib = Stdlib
 include Stdlib
 
 module Result = struct
-  type ('a, 'b) t = ('a, 'b) Result.t =
+  type ('a, 'b) t = ('a, 'b) result =
     | Ok of 'a
     | Error of 'b
 
-  type ('a, 'b) result = ('a, 'b) Result.t =
+  type ('a, 'b) result = ('a, 'b) t =
     | Ok of 'a
     | Error of 'b
 end

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -22,81 +22,53 @@ type nonrec bytes = bytes
 (** {2 Predefined modules}
     {3 Operations on predefined types} *)
 
-#if OCAML_VERSION >= (4, 08, 0)
-include (module type of Stdlib with
-  type fpclass = Stdlib.fpclass and
-  type in_channel = Stdlib.in_channel and
-  type out_channel = Stdlib.out_channel and
-  type open_flag = Stdlib.open_flag and
-  type 'a ref = 'a Stdlib.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Stdlib.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Stdlib.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Stdlib.format
-)
+#if OCAML_VERSION >= (4, 07, 0)
+include module type of struct
+  include Stdlib
+end
 
 module Result : sig
-  type ('a, 'b) t = ('a, 'b) Result.t =
+  type ('a, 'b) t = ('a, 'b) result =
     | Ok of 'a
     | Error of 'b
 
   (* we also expose Result.result for backward-compatibility
      with the Result package! *)
-  type ('a, 'b) result = ('a, 'b) Result.t =
+  type ('a, 'b) result = ('a, 'b) t =
     | Ok of 'a
     | Error of 'b
 end
 #else
-module Pervasives : (module type of Pervasives with
-  type fpclass = Pervasives.fpclass and
-  type in_channel = Pervasives.in_channel and
-  type out_channel = Pervasives.out_channel and
-  type open_flag = Pervasives.open_flag and
-  type 'a ref = 'a Pervasives.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Pervasives.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Pervasives.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Pervasives.format)
+module Pervasives = Pervasives
 
 module Stdlib = Pervasives
 
-include (module type of Pervasives with
-  type fpclass = Pervasives.fpclass and
-  type in_channel = Pervasives.in_channel and
-  type out_channel = Pervasives.out_channel and
-  type open_flag = Pervasives.open_flag and
-  type 'a ref = 'a Pervasives.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Pervasives.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Pervasives.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Pervasives.format)
+include module type of struct
+  include Pervasives
+end
 
-module Char : (module type of Char)
-module String : (module type of String)
-module Printexc : (module type of Printexc with
-  type raw_backtrace = Printexc.raw_backtrace and
-  type backtrace_slot = Printexc.backtrace_slot and
-  type location = Printexc.location)
-module Array : (module type of Array)
-module List : (module type of List)
-module Nativeint : (module type of Nativeint)
-module Int32 : (module type of Int32)
-module Int64 : (module type of Int64)
-module Lazy : (module type of Lazy)
-module Bytes : (module type of Bytes)
+module Char = Char
+module String = String
+module Printexc = Printexc
+module Array = Array
+module List = List
+module Nativeint = Nativeint
+module Int32 = Int32
+module Int64 = Int64
+module Lazy = Lazy
+module Bytes = Bytes
 
-(** {3 Data structures} *)
+module Hashtbl = Hashtbl
+module Queue = Queue
+module Stack = Stack
+module Set = Set
+module Map = Map
+module Weak = Weak
 
-module Hashtbl : (module type of Hashtbl with
-  type ('a, 'b) t = ('a, 'b) Hashtbl.t and
-  type statistics = Hashtbl.statistics)
-module Queue : (module type of Queue with
-  type 'a t = 'a Queue.t)
-module Stack : (module type of Stack with
-  type 'a t = 'a Stack.t)
-module Set : (module type of Set)
-module Map : (module type of Map)
-module Weak : (module type of Weak with
-  type 'a t = 'a Weak.t)
-module Buffer : (module type of Buffer with
-  type t = Buffer.t)
+module Printf = Printf
+module Format = Format
+module Buffer = Buffer
+
 module Result : sig
   type ('a, 'b) t = ('a, 'b) Result.result =
     | Ok of 'a
@@ -107,12 +79,4 @@ module Result : sig
     | Ok of 'a
     | Error of 'b
 end
-
-(** {3 Formatting} *)
-
-module Printf : (module type of Printf)
-module Format : (module type of Format with
-  type formatter_out_functions = Format.formatter_out_functions and
-  type formatter_tag_functions = Format.formatter_tag_functions and
-  type formatter = Format.formatter)
 #endif


### PR DESCRIPTION
Some equalities were missing in `Ppx_deriving_runtime`, for instance the equality between `Pervasives.result` and `Result.result`, which leads to some strange type errors (for instance, the one corrected here for OCaml <4.08: https://github.com/ocaml-ppx/ppx_deriving/pull/222/commits/f89e120c8f8fc1cd1e319bf3e8217d8e7e62a923).

Instead of trying to enumerate all equalities explicitly, this PR proposes to use the construction

```ocaml
include module type of struct
  include M
end
```

to precisely get the signature of `include M`.

Moreover, it seems that we do not lose anything by using module aliases in signatures.