### PR TITLE
Cherry picking some pre-ppxlib changes into master

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -222,7 +222,7 @@ let string_of_core_type typ =
 
 let string_of_constant_opt (constant : Parsetree.constant) : string option =
   match constant with
-  | Pconst_string (s, _, _) ->
+  | Pconst_string (s, _) ->
       Some s
   | _ -> None
 

--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -220,6 +220,18 @@ let create =
 let string_of_core_type typ =
   Format.asprintf "%a" Pprintast.core_type { typ with ptyp_attributes = [] }
 
+let string_of_constant_opt (constant : Parsetree.constant) : string option =
+  match constant with
+  | Pconst_string (s, _, _) ->
+      Some s
+  | _ -> None
+
+let string_of_expression_opt (e : Parsetree.expression) : string option =
+  match e with
+  | { pexp_desc = Pexp_constant constant } ->
+      string_of_constant_opt constant
+  | _ -> None
+
 module Arg = struct
   type 'a conv = expression -> ('a, string) Result.result
 

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -82,6 +82,14 @@ val raise_errorf : ?sub:Ocaml_common.Location.error list ->
 (** [string_of_core_type typ] unparses [typ], omitting any attributes. *)
 val string_of_core_type : Parsetree.core_type -> string
 
+(** [string_of_constant_opt c] returns [Some s] if the constant [c]
+    is a string [s], [None] otherwise. *)
+val string_of_constant_opt : Parsetree.constant -> string option
+
+(** [string_of_expression_opt e] returns [Some s] if the expression [e]
+    is a string constant [s], [None] otherwise. *)
+val string_of_expression_opt : Parsetree.expression -> string option
+
 (** {2 Option parsing} *)
 
 (** {!Arg} contains convenience functions that extract constants from

--- a/src/runtime/ppx_deriving_runtime.cppo.ml
+++ b/src/runtime/ppx_deriving_runtime.cppo.ml
@@ -70,6 +70,19 @@ module Result = struct
     | Ok of 'a
     | Error of 'b
 end
+module Option = struct
+  type 'a t = 'a option
+
+  let get o =
+    match o with
+    | None -> invalid_arg "get"
+    | Some x -> x
+
+  let to_result ~none o =
+    match o with
+    | None -> Error none
+    | Some x -> Ok x
+end
 
 include Pervasives
 #endif

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -79,4 +79,12 @@ module Result : sig
     | Ok of 'a
     | Error of 'b
 end
+
+module Option : sig
+  type 'a t = 'a option
+
+  val get : 'a t -> 'a
+
+  val to_result : none:'e -> 'a option -> ('a, 'e) result
+end
 #endif


### PR DESCRIPTION
This pull-request cherry-picks into `master` the following changes introduced in the `pre-ppxlib` branch:

- the `Option` compatibility module in `Ppx_deriving_runtime`,
- the `string_of_{expression,constant}_opt` functions in `Ppx_deriving`.