### PR TITLE
Cherry-picking stronger type equalities into pre-ppxlib

### DIFF
--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -21,92 +21,75 @@ type nonrec bytes = bytes
 
 (** {2 Predefined modules}
     {3 Operations on predefined types} *)
-
-#if OCAML_VERSION >= (4, 08, 0)
-include (module type of Stdlib with
-  type fpclass = Stdlib.fpclass and
-  type in_channel = Stdlib.in_channel and
-  type out_channel = Stdlib.out_channel and
-  type open_flag = Stdlib.open_flag and
-  type 'a ref = 'a Stdlib.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Stdlib.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Stdlib.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Stdlib.format
-)
+#if OCAML_VERSION >= (4, 07, 0)
+include module type of struct
+  include Stdlib
+end
 
 module Result : sig
-  type ('a, 'b) t = ('a, 'b) Result.t =
+  (* Type manifest shoud be [('a, 'b) result]:
+     - it can't be [Result.t] because [Result] is not defined in 4.07 std-lib
+       and the result package just exposes [Result.t] as an alias to [result]
+       without re-exporting the constructors
+     - it can't be [Result.result] because the [include Stdlib] above makes
+       [Result] be [Stdlib.Result] (shadowing the [Result] module from the
+       result package), and [Stdlib.Result] does not define [result] (that's
+       why we override the [Result] module as the first place. *)
+  type ('a, 'b) t = ('a, 'b) result =
     | Ok of 'a
     | Error of 'b
 
   (* we also expose Result.result for backward-compatibility
      with the Result package! *)
-  type ('a, 'b) result = ('a, 'b) Result.t =
+  type ('a, 'b) result = ('a, 'b) t =
     | Ok of 'a
     | Error of 'b
 end
 #else
-module Pervasives : (module type of Pervasives with
-  type fpclass = Pervasives.fpclass and
-  type in_channel = Pervasives.in_channel and
-  type out_channel = Pervasives.out_channel and
-  type open_flag = Pervasives.open_flag and
-  type 'a ref = 'a Pervasives.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Pervasives.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Pervasives.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Pervasives.format)
+module Pervasives = Pervasives
 
 module Stdlib = Pervasives
 
-include (module type of Pervasives with
-  type fpclass = Pervasives.fpclass and
-  type in_channel = Pervasives.in_channel and
-  type out_channel = Pervasives.out_channel and
-  type open_flag = Pervasives.open_flag and
-  type 'a ref = 'a Pervasives.ref and
-  type ('a, 'b, 'c, 'd, 'e, 'f) format6 = ('a, 'b, 'c, 'd, 'e, 'f) Pervasives.format6 and
-  type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'd) Pervasives.format4 and
-  type ('a, 'b, 'c) format = ('a, 'b, 'c) Pervasives.format)
+include module type of struct
+  include Pervasives
+end
 
-module Char : (module type of Char)
-module String : (module type of String)
-module Printexc : (module type of Printexc with
-  type raw_backtrace = Printexc.raw_backtrace and
-  type backtrace_slot = Printexc.backtrace_slot and
-  type location = Printexc.location)
-module Array : (module type of Array)
-module List : (module type of List)
-module Nativeint : (module type of Nativeint)
-module Int32 : (module type of Int32)
-module Int64 : (module type of Int64)
-module Lazy : (module type of Lazy)
-module Bytes : (module type of Bytes)
+module Char = Char
+module String = String
+module Printexc = Printexc
+module Array = Array
+module List = List
+module Nativeint = Nativeint
+module Int32 = Int32
+module Int64 = Int64
+module Lazy = Lazy
+module Bytes = Bytes
 
-(** {3 Data structures} *)
+module Hashtbl = Hashtbl
+module Queue = Queue
+module Stack = Stack
+module Set = Set
+module Map = Map
+module Weak = Weak
 
-module Hashtbl : (module type of Hashtbl with
-  type ('a, 'b) t = ('a, 'b) Hashtbl.t and
-  type statistics = Hashtbl.statistics)
-module Queue : (module type of Queue with
-  type 'a t = 'a Queue.t)
-module Stack : (module type of Stack with
-  type 'a t = 'a Stack.t)
-module Set : (module type of Set)
-module Map : (module type of Map)
-module Weak : (module type of Weak with
-  type 'a t = 'a Weak.t)
-module Buffer : (module type of Buffer with
-  type t = Buffer.t)
+module Printf = Printf
+module Format = Format
+module Buffer = Buffer
+
 module Result : sig
   type ('a, 'b) t = ('a, 'b) Result.result =
     | Ok of 'a
     | Error of 'b
 
-  (* we also expose Result.result for backward-compatibility *)
+  (* we also expose Result.result for backward-compatibility
+     with the Result package! *)
   type ('a, 'b) result = ('a, 'b) Result.result =
     | Ok of 'a
     | Error of 'b
 end
+#endif
+
+#if OCAML_VERSION < (4, 08, 0)
 module Option : sig
   type 'a t = 'a option
 
@@ -114,12 +97,4 @@ module Option : sig
 
   val to_result : none:'e -> 'a option -> ('a, 'e) Result.result
 end
-
-(** {3 Formatting} *)
-
-module Printf : (module type of Printf)
-module Format : (module type of Format with
-  type formatter_out_functions = Format.formatter_out_functions and
-  type formatter_tag_functions = Format.formatter_tag_functions and
-  type formatter = Format.formatter)
 #endif


### PR DESCRIPTION
This pull-request cherry-picks https://github.com/ocaml-ppx/ppx_deriving/pull/223 into `pre-ppxlib`.