### PR TITLE
Fix #183 (pre-ppxlib only): CI testing for our reverse dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   matrix:
-  - OCAML_VERSION=4.02 # we require >=4.02.2 but this picks 4.02.3
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.04
-  - OCAML_VERSION=4.05
-  - OCAML_VERSION=4.06
-  - OCAML_VERSION=4.07
-  - OCAML_VERSION=4.08
-  - OCAML_VERSION=4.09
-  - OCAML_VERSION=4.10
-  - OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
+  - REVDEPS=y OCAML_VERSION=4.02 # we require >=4.02.2 but this picks 4.02.3
+  - REVDEPS=y OCAML_VERSION=4.03
+  - REVDEPS=y OCAML_VERSION=4.04
+  - REVDEPS=y OCAML_VERSION=4.05
+  - REVDEPS=y OCAML_VERSION=4.06
+  - REVDEPS=y OCAML_VERSION=4.07
+  - REVDEPS=y OCAML_VERSION=4.08
+  - REVDEPS=y OCAML_VERSION=4.09
+  - REVDEPS=y OCAML_VERSION=4.10
+  - REVDEPS=y OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
     PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411"
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,106 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   matrix:
-  - REVDEPS=y OCAML_VERSION=4.02 # we require >=4.02.2 but this picks 4.02.3
-  - REVDEPS=y OCAML_VERSION=4.03
-  - REVDEPS=y OCAML_VERSION=4.04
-  - REVDEPS=y OCAML_VERSION=4.05
-  - REVDEPS=y OCAML_VERSION=4.06
-  - REVDEPS=y OCAML_VERSION=4.07
-  - REVDEPS=y OCAML_VERSION=4.08
-  - REVDEPS=y OCAML_VERSION=4.09
-  - REVDEPS=y OCAML_VERSION=4.10
-  - REVDEPS=y OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
-    PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411"
+  - OCAML_VERSION=4.02 # we require >=4.02.2 but this picks 4.02.3
+    REVDEPS="ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.03
+    REVDEPS="ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.04
+    REVDEPS="ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.05
+    REVDEPS="ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.06
+    REVDEPS="ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.07
+    REVDEPS="ppx_deriving_hardcaml
+      ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.08
+    REVDEPS="ppx_deriving_hardcaml
+      ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.09
+    REVDEPS="ppx_deriving_hardcaml
+      ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.10
+    REVDEPS="ppx_deriving_hardcaml
+      ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_cmdliner
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
+  - OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
+    PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
+      ppx_deriving_yojson:https://github.com/thierry-martinez/ppx_deriving_yojson#411_lightning"
+    REVDEPS="ppx_deriving_hardcaml
+      ppx_deriving_crowbar
+      ppx_deriving_yojson
+      ppx_deriving_madcast
+      ppx_deriving_protocol
+      ppx_deriving_rpc
+      ppx_deriving_argparse
+      ppx_deriving_protobuf
+      ppx_deriving_morphism
+      visitors"
 os:
   - linux


### PR DESCRIPTION
This should implement @gasche suggestion:
https://github.com/ocaml-ppx/ppx_deriving/issues/183

We should do that for `master` as well (I expect there will be
more failures there!) but I begin here.