### PR TITLE
Remove ppx_deriving_protocol from REVDEPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
       ppx_deriving_crowbar
       ppx_deriving_yojson
       ppx_deriving_madcast
-      ppx_deriving_protocol
       ppx_deriving_rpc
       ppx_deriving_argparse
       ppx_deriving_cmdliner


### PR DESCRIPTION
Gabriel Scherer reported that ppx_deriving_protocol does not depend on ppx_deriving.

https://github.com/ocaml-ppx/ppx_deriving/pull/227#issuecomment-633576290