### PR TITLE
Fix and improve the opam file

### DIFF
--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -8,23 +8,22 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
 tags: [ "syntax" ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune"     {>= "1.6.3"}
-  "cppo"     {build}
-  "ppxfind"  {build}
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {build}
   "ocaml-migrate-parsetree"
   "ppx_derivers"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
   "result"
   "ounit" {with-test}
-  "ocaml" {>= "4.05.0"}
 ]
-synopsis: "Type-driven code generation for OCaml >=4.04.1"
+synopsis: "Type-driven code generation for OCaml"
 description: """
 ppx_deriving provides common infrastructure for generating
 code based on type definitions, and a set of useful plugins

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.6.3"}
   "cppo" {build}
+  "ocamlfind"
   "ocaml-migrate-parsetree"
   "ppx_derivers"
   "ppxlib" {>= "0.9.0" & < "0.14.0"}


### PR DESCRIPTION
This PR:
* Uses `{dev}` instead of `{pinned}` for the `dune subst` command (see https://github.com/ocaml/dune/pull/3647)
* Removes mentions of unsupported versions of OCaml
* Restrict the `ppxlib` dependency to `< 0.14.0`. Currently fails with this error with `ppxlib.0.14.0`:
```
#=== ERROR while compiling ppx_deriving.dev ===================================#
# context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.10.0 | pinned(git://github.com/ocaml-ppx/ppx_deriving.git#e6cbddb8)
# path                 ~/.opam/4.10/.opam-switch/build/ppx_deriving.dev
# command              ~/.opam/4.10/bin/dune build -p ppx_deriving -j 71
# exit-code            1
# env-file             ~/.opam/log/ppx_deriving-146-2b4347.env
# output-file          ~/.opam/log/ppx_deriving-146-2b4347.out
### output ###
# Error: This expression has type Ppxlib.core_type list
# [...]
#     ocamlopt src/api/.ppx_deriving_api.objs/native/ppx_deriving.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.10/bin/ocamlopt.opt -w -9 -g -I src/api/.ppx_deriving_api.objs/byte -I src/api/.ppx_deriving_api.objs/native -I /home/opam/.opam/4.10/lib/base -I /home/opam/.opam/4.10/lib/base/base_internalhash_types -I /home/opam/.opam/4.10/lib/base/caml -I /home/opam/.opam/4.10/lib/base/shadow_stdlib -I /home/opam/.opam/4.10/lib/ocaml-compiler-libs/common -I /home/o[...]
# File "ppx_deriving.cppo.ml", line 412, characters 68-69:
# Error: This expression has type Ppxlib.core_type list
#        but an expression was expected of type
#          Migrate_parsetree__Migrate_parsetree_versions.OCaml_408.Ast.Parsetree.core_type
#          list
#        Type Ppxlib.core_type = Parsetree.core_type
#        is not compatible with type
#          Migrate_parsetree__Migrate_parsetree_versions.OCaml_408.Ast.Parsetree.core_type
#            = Migrate_parsetree.Ast_408.Parsetree.core_type 
```