### PR TITLE
Remove unused dependencies and upgrade to ounit2

### DIFF
--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_derivers"
   "ppxlib" {>= "0.18.0"}
   "result"
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 synopsis: "Type-driven code generation for OCaml"
 description: """

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -17,8 +17,6 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.6.3"}
   "cppo" {build}
-  "ocamlfind"
-  "ocaml-migrate-parsetree"
   "ppx_derivers"
   "ppxlib" {>= "0.18.0"}
   "result"

--- a/src/api/dune
+++ b/src/api/dune
@@ -9,8 +9,7 @@
    compiler-libs.common
    ppxlib
    result
-   ppx_derivers
-   ocaml-migrate-parsetree))
+   ppx_derivers))
 
 (rule
  (deps ppx_deriving.cppo.ml)

--- a/src/dune
+++ b/src/dune
@@ -5,7 +5,7 @@
 
 (executable
  (name ppx_deriving_main)
- (libraries ppx_deriving_api findlib.dynload compiler-libs.common)
+ (libraries ppx_deriving_api compiler-libs.common)
  (link_flags :standard -linkall)
  (preprocess (pps ppxlib.metaquot)))
 

--- a/src_test/api/dune
+++ b/src_test/api/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_api)
- (libraries oUnit compiler-libs.common ppx_deriving.api)
+ (libraries ounit2 compiler-libs.common ppx_deriving.api)
  (preprocess (pps ppxlib.metaquot)))

--- a/src_test/create/dune
+++ b/src_test/create/dune
@@ -1,4 +1,4 @@
 (test
  (name test_deriving_create)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.create ppx_deriving.show)))

--- a/src_test/deriving/dune
+++ b/src_test/deriving/dune
@@ -1,4 +1,4 @@
 (test
  (name test_ppx_deriving)
- (libraries oUnit compiler-libs.common ppx_deriving.api)
+ (libraries ounit2 compiler-libs.common ppx_deriving.api)
  (preprocess (pps ppx_deriving.ord ppx_deriving.show ppx_deriving.eq)))

--- a/src_test/enum/dune
+++ b/src_test/enum/dune
@@ -1,4 +1,4 @@
 (test
  (name test_deriving_enum)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.enum ppx_deriving.show)))

--- a/src_test/eq/dune
+++ b/src_test/eq/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_eq)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.eq ppx_deriving.show)))

--- a/src_test/fold/dune
+++ b/src_test/fold/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_fold)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.fold)))

--- a/src_test/iter/dune
+++ b/src_test/iter/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_iter)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.iter ppx_deriving.show)))

--- a/src_test/make/dune
+++ b/src_test/make/dune
@@ -1,4 +1,4 @@
 (test
  (name test_deriving_make)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.make ppx_deriving.show)))

--- a/src_test/map/dune
+++ b/src_test/map/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_map)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.map ppx_deriving.show)))

--- a/src_test/ord/dune
+++ b/src_test/ord/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_ord)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.ord)))

--- a/src_test/runtime/dune
+++ b/src_test/runtime/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_runtime)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.eq ppx_deriving.show)))

--- a/src_test/show/dune
+++ b/src_test/show/dune
@@ -5,5 +5,5 @@
 
 (test
  (name test_deriving_show)
- (libraries oUnit ppx_deriving.runtime)
+ (libraries ounit2 ppx_deriving.runtime)
  (preprocess (pps ppx_deriving.show)))


### PR DESCRIPTION
This PR cherry-picks a few commits from https://github.com/ocaml-ppx/ppx_deriving/pull/240 as it is a bit harder than first thought to get rid of the dependency on `result`.
I'll do one last release after this.