### PR TITLE
Remove unnecessary ppx_derivers dependency.

### DIFF
--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -18,7 +18,6 @@ depends: [
   "dune" {>= "1.6.3"}
   "cppo" {build}
   "ocamlfind"
-  "ppx_derivers"
   "ppxlib" {>= "0.20.0"}
   "result"
   "ounit2" {with-test}


### PR DESCRIPTION
It's unnecessary since the port to the recent ppxlib: https://github.com/ocaml-ppx/ppx_derivers/issues/6