### PR TITLE
Make ppx deriving compatible with preprocessor type ppxlib extensions

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -817,5 +817,5 @@ let hash_variant s =
    driver. *)
 let () =
   Ppxlib.Driver.register_transformation "ppx_deriving"
-    ~preprocess_impl:map_structure
-    ~preprocess_intf:map_signature
+    ~impl:map_structure
+    ~intf:map_signature


### PR DESCRIPTION
This is an attempt at fixing the last issue of ppx_deriving with ocaml-migrate-parsetree 2.0

The problem was that making ppx_deriving a "preprocesor type ppxlib extension", made it imcompatible with other "preprocessor type ppxlib extensions" such as `optcomp` and triggered errors in a handful of packages in opam-repository.

From what I understand this was done to enforce an order between ppxs, and when mentioning this issue the ppxlib devs told me to use the `Ppxlib.Deriving` API. However, I'm no expert in either `ppxlib` nor `ppx_deriving` and didn't manage to make it work in a reasonable time.

Here I'm using the cheap method of simply stop caring about orders, I've ran a test on every opam packages for OCaml 4.11 with this change and no issue was found. So, to me, this seems safe to do so, since from what I understand, the previous code using OMP1 did not care about order either.

What do you think? @thierry-martinez @gasche 