### PR TITLE
Fix some of Ast_convenience's functions when giving a full path ident (e.g. M.ident, not just ident)

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -17,7 +17,7 @@ module Ast_convenience = struct
     mknoloc s
 
   let lid_of_string s =
-    mknoloc (Lident s)
+    mknoloc (Longident.parse s)
 
   let unit () =
     let loc = !Ast_helper.default_loc in


### PR DESCRIPTION
This is required for `ppx_deriving_protobuf` to work with minimal changes. See: https://github.com/ocaml-ppx/ppx_deriving_protobuf/pull/39