### PR TITLE
[WIP] Deprecate the ppx_deriving API in favour of ppxlib

### DIFF
--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -1,5 +1,7 @@
 (** Public API of [ppx_deriving] executable. *)
 
+[@@@ocaml.deprecated "The ppx_deriving API is deprecated in favour of ppxlib"]
+
 open Ppxlib
 
 type tyvar = string Location.loc

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -2,6 +2,8 @@
     modules operating on them, so that ppx_deriving plugins operate
     in a well-defined environment. *)
 
+[@@@ocaml.deprecated "The ppx_deriving API is deprecated in favour of ppxlib"]
+
 (** {2 Predefined types} *)
 type nonrec int = int
 type nonrec char = char


### PR DESCRIPTION
This PR has two goals:
1) Add a deprecation warning shown to the users of the ppx_deriving API (note that the warning is fatal by default in dune)
2) TODO: Use `ppxlib` for the builtin deriving plugins (show, eq, ord, …). This will help pinpoint the possible issues that users will encounter when migrating and help the `ppxlib` API itself by adding helpful functions if something is missing there.

*I don't have time or motivation to implement the last point right now, so if anyone has either of those things feel free to try it out in the meantime.*