### PR TITLE
Optimize forwarding in eq and ord plugins

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -320,6 +320,8 @@ let quote ~quoter expr =
   let loc = !Ast_helper.default_loc in
   let name = "__" ^ string_of_int quoter.next_id in
   let (binding_body, quoted_expr) = match expr with
+    (* Optimize identifier quoting by avoiding closure.
+       See https://github.com/ocaml-ppx/ppx_deriving/pull/252. *)
     | { pexp_desc = Pexp_ident _; _ } ->
       (expr, evar name)
     | _ ->

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -66,10 +66,7 @@ and expr_of_typ quoter typ =
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   let expr_of_typ = expr_of_typ quoter in
   match attr_equal typ.ptyp_attributes with
-  | Some fn ->
-    let fwd = Ppx_deriving.quote ~quoter fn in
-    (* eta-expansion is necessary for recursive groups *)
-    [%expr fun x -> [%e fwd] x]
+  | Some fn -> Ppx_deriving.quote ~quoter fn (* eta-expanded if outermost *)
   | None ->
     match typ with
     | [%type: _] -> [%expr fun _ _ -> true]
@@ -115,9 +112,7 @@ and expr_of_typ quoter typ =
         [%expr fun (lazy x) (lazy y) -> [%e expr_of_typ typ] x y]
       | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
         let equal_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "equal") lid)) in
-        let fwd = app (Ppx_deriving.quote ~quoter equal_fn) (List.map expr_of_typ args) in
-        (* eta-expansion is necessary for recursive groups *)
-        [%expr fun x -> [%e fwd] x]
+        app (Ppx_deriving.quote ~quoter equal_fn) (List.map expr_of_typ args) (* eta-expanded if outermost *)
       | _ -> assert false
       end
     | { ptyp_desc = Ptyp_tuple typs } ->
@@ -192,6 +187,10 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       raise_errorf ~loc "%s cannot be derived for open types" deriver
   in
   let polymorphize = Ppx_deriving.poly_fun_of_type_decl type_decl in
+  let eta_expand expr = match expr with
+    | { pexp_desc = Pexp_fun _; _ } -> expr
+    | _ -> [%expr fun x -> [%e expr] x] (* eta-expansion is necessary for recursive groups *)
+  in
   let out_type =
     Ppx_deriving.strong_type_of_type @@
       core_type_of_decl  ~options ~path type_decl in
@@ -199,7 +198,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "equal") type_decl) in
   [Vb.mk ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]]
          (Pat.constraint_ eq_var out_type)
-         (Ppx_deriving.sanitize ~quoter (polymorphize comparator))]
+         (Ppx_deriving.sanitize ~quoter (eta_expand (polymorphize comparator)))]
 
 let () =
   Ppx_deriving.(register (create deriver

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -66,7 +66,10 @@ and expr_of_typ quoter typ =
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   let expr_of_typ = expr_of_typ quoter in
   match attr_equal typ.ptyp_attributes with
-  | Some fn -> Ppx_deriving.quote ~quoter fn
+  | Some fn ->
+    let fwd = Ppx_deriving.quote ~quoter fn in
+    (* eta-expansion is necessary for recursive groups *)
+    [%expr fun x -> [%e fwd] x]
   | None ->
     match typ with
     | [%type: _] -> [%expr fun _ _ -> true]

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -67,7 +67,7 @@ and expr_of_typ quoter typ =
   let loc = typ.ptyp_loc in
   let expr_of_typ = expr_of_typ quoter in
   match attr_compare typ.ptyp_attributes with
-  | Some fn -> Ppx_deriving.quote ~quoter fn (* eta-expanded if outermost *)
+  | Some fn -> Ppx_deriving.quote ~quoter fn
   | None ->
     let typ = Ppx_deriving.remove_pervasives ~deriver typ in
     match typ with
@@ -125,7 +125,7 @@ and expr_of_typ quoter typ =
         [%expr fun (lazy x) (lazy y) -> [%e expr_of_typ typ] x y]
       | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
         let compare_fn = Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix "compare") lid)) in
-        app (Ppx_deriving.quote ~quoter compare_fn) (List.map expr_of_typ args) (* eta-expanded if outermost *)
+        app (Ppx_deriving.quote ~quoter compare_fn) (List.map expr_of_typ args)
       | _ -> assert false
       end
     | { ptyp_desc = Ptyp_tuple typs } ->
@@ -223,9 +223,12 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       raise_errorf ~loc "%s cannot be derived for open types" deriver
   in
   let polymorphize = Ppx_deriving.poly_fun_of_type_decl type_decl in
-  let eta_expand expr = match expr with
+  let eta_expand expr =
+    (* Ensure expr is statically constructive by eta-expanding non-funs.
+       See https://github.com/ocaml-ppx/ppx_deriving/pull/252. *)
+    match expr with
     | { pexp_desc = Pexp_fun _; _ } -> expr
-    | _ -> [%expr fun x -> [%e expr] x] (* eta-expansion is necessary for recursive groups *)
+    | _ -> [%expr fun x -> [%e expr] x]
   in
   let out_type =
     Ppx_deriving.strong_type_of_type @@

--- a/src_test/eq/test_deriving_eq.cppo.ml
+++ b/src_test/eq/test_deriving_eq.cppo.ml
@@ -124,6 +124,10 @@ let test_poly_app ctxt =
   assert_equal ~printer true (equal_poly_app 1.0 1.0);
   assert_equal ~printer false (equal_poly_app 1.0 2.0)
 
+type poly_app_custom = float poly_abs_custom [@equal equal_poly_abs_custom (=)]
+and 'a poly_abs_custom = 'a
+[@@deriving eq]
+
 module List = struct
   type 'a t = [`Cons of 'a | `Nil]
   [@@deriving eq]

--- a/src_test/ord/test_deriving_ord.cppo.ml
+++ b/src_test/ord/test_deriving_ord.cppo.ml
@@ -151,6 +151,10 @@ let test_poly_app ctxt =
   assert_equal ~printer 0 (compare_poly_app 1.0 1.0);
   assert_equal ~printer (-1) (compare_poly_app 1.0 2.0)
 
+type poly_app_custom = float poly_abs_custom [@compare compare_poly_abs_custom Stdlib.compare]
+and 'a poly_abs_custom = 'a
+[@@deriving ord]
+
 module List = struct
   type 'a t = [`Cons of 'a | `Nil]
   [@@deriving ord]


### PR DESCRIPTION
After switching a large project from manual `equal` and `compare` implementations to ones derived by ppx_deriving (https://github.com/goblint/analyzer/pull/227), we noticed significant performance decreases in in those functions (https://github.com/goblint/analyzer/issues/265).

Benchmarking the generated `equal` functions directly (https://github.com/goblint/analyzer/blob/a21f33511183074c693c15269990210b283ae045/bench/deriving/benchEq.ml, executable independently from our project) showed up to **3 times** slowdown. For example, when the old manual implementation
```ocaml
let equal (x1, y1) (x2, y2) = Int.equal x1 x2 && String.equal y1 y2
```
was replaced with one derived for `Int.t * String.t`.
The modules `Int` and `String` are just chosen as example, we often use functors where the modules come abstractly from arguments, so using primitive types isn't an option for deriving.

### Inefficient derived code
Currently, the following implementation is derived:
```ocaml
let equal =
  let __1 () = String.equal
  and __0 () = Int.equal in
  ((let open! ((Ppx_deriving_runtime)[@ocaml.warning "-A"]) in
    fun (lhs0, lhs1) ->
      fun (rhs0, rhs1) ->
        ((fun x -> (__0 ()) x) lhs0 rhs0) &&
          ((fun x -> (__1 ()) x) lhs1 rhs1))
  [@ocaml.warning "-A"])
```
The benchmarks confirm that this literal code performs the same as the derived one.

### Optimizations
This PR suggests two optimizations for forwarding the `equal` calls.

#### Avoid unnecessary eta-expansion
PR #55 introduced eta-expansion to forwarded calls. This was necessary since derived implementations for mutual recursion in the generated `let rec` must be _statically constructive_ (https://ocaml.org/manual/letrecvalues.html), so expanding a forwarding call into a `fun` works around the restriction.

The problem in this case is that the eta-expansion is added to _all_ forwarding calls, including those deeper in the resulting `equal` implementation, where the restriction doesn't apply any more because the outermost expression is a `fun` already. AFAIK, eta-expansion is only needed at the top level if it's not a `fun` already (most cases of `expr_of_typ` are anyway). Therefore this PR implements exactly that. The linked benchmarks show a 50%…300% speedup from this change.

#### Avoid unnecessary closures in quoting
Issue #57 and commit https://github.com/ocaml-ppx/ppx_deriving/commit/c3bee7b96fb048c1a2431629109b532637c30df7 introduced quoting to forwarded calls. The quoting mechanism introduces functions with `()` argument. There is no explanation why, but I'm guessing it's to be lazy: in case the quoted expression involves some computation, then don't perform it immediately at the beginning (it might not be necessary due to short-circuiting, etc) but perform it each time it's actually used, just like if the quoted expression where independently at each use.

The problem in this case is that forward calls being quoted are just identifier expressions, which AFAIK cannot be performing any computation on their own. Therefore this PR implements a special case of quoting just identifiers to be without the `()` argument. The linked benchmarks show a 200%…400% speedup from this change on the pair examples. Just forwarding to a single function doesn't seem to gain any speedup, nor slowdown.

### Efficient derived code
As a result of these changes, the new derived code for the example above is:
```ocaml
let equal =
  let __1 = String.equal
  and __0 = Int.equal in
  ((let open! ((Ppx_deriving_runtime)[@ocaml.warning "-A"]) in
      fun (lhs0, lhs1) ->
        fun (rhs0, rhs1) -> (__0 lhs0 rhs0) && (__1 lhs1 rhs1))
    [@ocaml.warning "-A"])
```

And overall the derived implementations seem to be at least **3 times** faster, bringing them mostly on par with the manual implementations.