### PR TITLE
chore: remove artifact

### DIFF
--- a/dune
+++ b/dune
@@ -1,5 +1,3 @@
 (env
  (_
   (flags :standard -w -27-9))) ; TODO: Use the full standard flags
-
-(copy_files# src_plugins/compat_macros.cppo)


### PR DESCRIPTION
compat_macros.cppo doesn't exist

@kit-ty-kate there's no bug, but it's confusing to keep this