### PR TITLE
Fix ord on variants conflicting with `Result`

### DIFF
--- a/src_test/eq/test_deriving_eq.cppo.ml
+++ b/src_test/eq/test_deriving_eq.cppo.ml
@@ -148,6 +148,13 @@ let test_result_result ctxt =
   assert_equal ~printer false (eq (Ok "123") (Error 123));
   assert_equal ~printer false (eq (Error 123) (Error 0))
 
+module ResultOverride = struct
+  type t =
+    | Ok
+    | Error
+  [@@deriving eq]
+end
+
 let suite = "Test deriving(eq)" >::: [
     "test_simple"        >:: test_simple;
     "test_array"         >:: test_arr;

--- a/src_test/ord/test_deriving_ord.cppo.ml
+++ b/src_test/ord/test_deriving_ord.cppo.ml
@@ -179,6 +179,13 @@ let test_record_order ctxt =
   assert_equal ~printer (0) (compare_ab { a = 1; b = 2; } { a = 1; b = 2; });
   assert_equal ~printer (1) (compare_ab { a = 2; b = 2; } { a = 1; b = 2; })
 
+module ResultOverride = struct
+  type t =
+    | Ok
+    | Error
+  [@@deriving ord]
+end
+
 let suite = "Test deriving(ord)" >::: [
     "test_simple"        >:: test_simple;
     "test_variant"       >:: test_variant;


### PR DESCRIPTION
Closes #254. Besides `Error` also applies to `Ok`, coming from `Ppx_deriving_runtime`.

Conceptually the fix is simple: just add a type constraint to the `to_int` function generated into the `wildcard_case` of variant comparison. This forces type-directed construction resolution to correctly use the constructor from our type instead of `Result`.

The tricky part was not breaking other tests, where a new variant type is defined with the same name as a standard one, e.g. `bool`. In that case the `to_int` type constraint inside the comparator must still refer to the outer `bool` type being declared, not the one from `Ppx_deriving_runtime`, which happens to be opened at that point due to `sanitize`.
A local module definition `Ppx_deriving_ord_helper` is used to capture the type being declared outside of `sanitize`, such that inside it, we can refer to the correct `bool`. Hopefully such type-only local module doesn't have any runtime cost (?), otherwise I'll have to make it conditional to only happen for variant types (currently it's generated unconditionally and otherwise just unused).