### PR TITLE
Port standard plugins to ppxlib registration and attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 (unreleased)
 ------------
 
+* Port standard plugins to ppxlib registration and attributes
+  #263
+  (Simmo Saan)
+
 * Introduce `Ppx_deriving_runtime.Stdlib` with OCaml >= 4.07. This module
   already exists in OCaml < 4.07 but was missing otherwise.
 

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -19,7 +19,7 @@ depends: [
   "cppo" {build}
   "ocamlfind"
   "ppx_derivers"
-  "ppxlib" {>= "0.30.0"}
+  "ppxlib" {>= "0.32.0"}
   "result"
   "ounit2" {with-test}
 ]

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -19,7 +19,7 @@ depends: [
   "cppo" {build}
   "ocamlfind"
   "ppx_derivers"
-  "ppxlib" {>= "0.29.0"}
+  "ppxlib" {>= "0.30.0"}
   "result"
   "ounit2" {with-test}
 ]

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -19,7 +19,7 @@ depends: [
   "cppo" {build}
   "ocamlfind"
   "ppx_derivers"
-  "ppxlib" {>= "0.27.0"}
+  "ppxlib" {>= "0.29.0"}
   "result"
   "ounit2" {with-test}
 ]

--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -19,7 +19,7 @@ depends: [
   "cppo" {build}
   "ocamlfind"
   "ppx_derivers"
-  "ppxlib" {>= "0.20.0"}
+  "ppxlib" {>= "0.27.0"}
   "result"
   "ounit2" {with-test}
 ]

--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -309,12 +309,12 @@ let attr_warning expr =
     attr_loc = loc;
   }
 
-type quoter = Quoter.t
+type quoter = Expansion_helpers.Quoter.t
 
-let create_quoter () = Quoter.create ()
+let create_quoter () = Expansion_helpers.Quoter.create ()
 
 let quote ~quoter expr =
-  Quoter.quote quoter expr
+  Expansion_helpers.Quoter.quote quoter expr
 
 let sanitize ?(module_=Lident "Ppx_deriving_runtime") ?(quoter=create_quoter ()) expr =
   let loc = !Ast_helper.default_loc in
@@ -324,7 +324,7 @@ let sanitize ?(module_=Lident "Ppx_deriving_runtime") ?(quoter=create_quoter ())
     Exp.open_ ~loc ~attrs
       (Opn.mk ~loc ~attrs ~override:Override (Mod.ident ~loc ~attrs modname))
       expr in
-  let sanitized = Quoter.sanitize quoter body in
+  let sanitized = Expansion_helpers.Quoter.sanitize quoter body in
   (* ppxlib quoter uses Recursive, ppx_deriving's used Nonrecursive - silence warning *)
   { sanitized with pexp_attributes = attr_warning [%expr "-39"] :: sanitized.pexp_attributes}
 

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -390,5 +390,3 @@ module Ast_convenience : sig
     val optional : string -> arg_label
   end
 end
-
-val module_from_input_name: unit -> label list

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -44,7 +44,6 @@ type deriver = {
 
 (** [register deriver] registers [deriver] according to its [name] field. *)
 val register : deriver -> unit
-[@@deprecated]
 
 (** [add_register_hook hook] adds [hook] to be executed whenever a new deriver
     is registered. *)
@@ -72,7 +71,6 @@ val create :
                            path:string list ->
                            module_type_declaration -> signature) ->
   unit -> deriver
-[@@deprecated]
 
 (** [lookup name] looks up a deriver called [name]. *)
 val lookup : string -> deriver option
@@ -171,7 +169,6 @@ let deriver = "index"
       in error messages. *)
   val get_expr : deriver:string -> 'a conv -> expression -> 'a
 end
-[@@deprecated]
 
 (** {2 Hygiene} *)
 
@@ -230,7 +227,6 @@ val mangle_lid : ?fixpoint:string ->
     or [\[\@deriver.attr\]] if any attribute with name starting with [\@deriver] exists,
     or [\[\@attr\]] otherwise. *)
 val attr : deriver:string -> string -> attributes -> attribute option
-[@@deprecated]
 
 (** [attr_warning expr] builds the attribute [\@ocaml.warning expr] *)
 val attr_warning: expression -> attribute

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -386,3 +386,5 @@ module Ast_convenience : sig
     val optional : string -> arg_label
   end
 end
+
+val module_from_input_name: unit -> label list

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -44,6 +44,7 @@ type deriver = {
 
 (** [register deriver] registers [deriver] according to its [name] field. *)
 val register : deriver -> unit
+[@@deprecated]
 
 (** [add_register_hook hook] adds [hook] to be executed whenever a new deriver
     is registered. *)
@@ -71,6 +72,7 @@ val create :
                            path:string list ->
                            module_type_declaration -> signature) ->
   unit -> deriver
+[@@deprecated]
 
 (** [lookup name] looks up a deriver called [name]. *)
 val lookup : string -> deriver option
@@ -169,6 +171,7 @@ let deriver = "index"
       in error messages. *)
   val get_expr : deriver:string -> 'a conv -> expression -> 'a
 end
+[@@deprecated]
 
 (** {2 Hygiene} *)
 
@@ -227,6 +230,7 @@ val mangle_lid : ?fixpoint:string ->
     or [\[\@deriver.attr\]] if any attribute with name starting with [\@deriver] exists,
     or [\[\@attr\]] otherwise. *)
 val attr : deriver:string -> string -> attributes -> attribute option
+[@@deprecated]
 
 (** [attr_warning expr] builds the attribute [\@ocaml.warning expr] *)
 val attr_warning: expression -> attribute

--- a/src_plugins/create/ppx_deriving_create.cppo.ml
+++ b/src_plugins/create/ppx_deriving_create.cppo.ml
@@ -27,8 +27,7 @@ let attribute_get2 attr1 x1 attr2 x2 =
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
-    let is_main = Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label in
-    if is_main then
+    if Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label then
       match main with
       | Some _ -> raise_errorf ~loc:pld_loc "Duplicate [@deriving.%s.main] annotation" deriver
       | None -> Some label, labels
@@ -57,9 +56,8 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
-        let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        if split then
+        if Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in
@@ -101,9 +99,8 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
         match attribute_get2 ct_attr_default pld_type label_attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
-        let split = Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        if split then
+        if Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in

--- a/src_plugins/create/ppx_deriving_create.cppo.ml
+++ b/src_plugins/create/ppx_deriving_create.cppo.ml
@@ -118,11 +118,15 @@ let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl)) typ)]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~type_decl_str: (fun ~options ~path type_decls ->
-       [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-       List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/create/ppx_deriving_create.cppo.ml
+++ b/src_plugins/create/ppx_deriving_create.cppo.ml
@@ -12,13 +12,11 @@ let attr_default context = Attribute.declare "deriving.create.default" context
 let ct_attr_default = attr_default Attribute.Context.core_type
 let label_attr_default = attr_default Attribute.Context.label_declaration
 
-let attr_split context = Attribute.declare "deriving.create.split" context
-  Ast_pattern.(pstr nil) ()
+let attr_split context = Attribute.declare_flag "deriving.create.split" context
 let ct_attr_split = attr_split Attribute.Context.core_type
 let label_attr_split = attr_split Attribute.Context.label_declaration
 
-let attr_main context = Attribute.declare "deriving.create.main" context
-  Ast_pattern.(pstr nil) ()
+let attr_main context = Attribute.declare_flag "deriving.create.main" context
 let ct_attr_main = attr_main Attribute.Context.core_type
 let label_attr_main = attr_main Attribute.Context.label_declaration
 

--- a/src_plugins/create/ppx_deriving_create.cppo.ml
+++ b/src_plugins/create/ppx_deriving_create.cppo.ml
@@ -27,10 +27,7 @@ let attribute_get2 attr1 x1 attr2 x2 =
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
-    let is_main = match attribute_get2 ct_attr_main pld_type label_attr_main label with
-      | Some () -> true
-      | None -> false
-    in
+    let is_main = Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label in
     if is_main then
       match main with
       | Some _ -> raise_errorf ~loc:pld_loc "Duplicate [@deriving.%s.main] annotation" deriver
@@ -60,10 +57,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
-        let split = match attribute_get2 label_attr_split label ct_attr_split pld_type with
-          | Some () -> true
-          | None -> false
-        in
+        let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         if split then
           match pld_type with
@@ -107,10 +101,7 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
         match attribute_get2 ct_attr_default pld_type label_attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
-        let split = match attribute_get2 ct_attr_split pld_type label_attr_split label with
-          | Some () -> true
-          | None -> false
-        in
+        let split = Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         if split then
           match pld_type with

--- a/src_plugins/create/ppx_deriving_create.cppo.ml
+++ b/src_plugins/create/ppx_deriving_create.cppo.ml
@@ -9,8 +9,7 @@ let raise_errorf = Ppx_deriving.raise_errorf
 
 let attr_default context = Attribute.declare "deriving.create.default" context
   Ast_pattern.(single_expr_payload __) (fun e -> e)
-let ct_attr_default = attr_default Attribute.Context.core_type
-let label_attr_default = attr_default Attribute.Context.label_declaration
+let attr_default = (attr_default Attribute.Context.label_declaration, attr_default Attribute.Context.core_type)
 
 let attr_split context = Attribute.declare_flag "deriving.create.split" context
 let ct_attr_split = attr_split Attribute.Context.core_type
@@ -20,10 +19,10 @@ let attr_main context = Attribute.declare_flag "deriving.create.main" context
 let ct_attr_main = attr_main Attribute.Context.core_type
 let label_attr_main = attr_main Attribute.Context.label_declaration
 
-let attribute_get2 attr1 x1 attr2 x2 =
-  match Attribute.get attr1 x1, Attribute.get attr2 x2 with
-  | Some _ as y, _ -> y
-  | None, y -> y
+let get_label_attribute (label_attr, ct_attr) label =
+  match Attribute.get label_attr label with
+  | Some _ as v -> v
+  | None -> Attribute.get ct_attr label.pld_type
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
@@ -52,7 +51,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
           Exp.fun_ Label.nolabel None (punit ()) (record fields)
       in
       List.fold_left (fun accum ({ pld_name = { txt = name }; pld_type; pld_attributes } as label) ->
-        match attribute_get2 label_attr_default label ct_attr_default pld_type with
+        match get_label_attribute attr_default label with
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
@@ -96,7 +95,7 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
           Typ.arrow Label.nolabel (tconstr "unit" []) typ
       in
       List.fold_left (fun accum ({ pld_name = { txt = name; loc }; pld_type; pld_attributes } as label) ->
-        match attribute_get2 ct_attr_default pld_type label_attr_default label with
+        match get_label_attribute attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in

--- a/src_plugins/enum/ppx_deriving_enum.cppo.ml
+++ b/src_plugins/enum/ppx_deriving_enum.cppo.ml
@@ -119,11 +119,15 @@ let sig_of_type ~options ~path type_decl =
    Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Suffix "of_enum") type_decl))
              [%type: Ppx_deriving_runtime.int -> [%t typ] Ppx_deriving_runtime.option])]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~type_decl_str: (fun ~options ~path type_decls ->
-       [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-       List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/enum/ppx_deriving_enum.cppo.ml
+++ b/src_plugins/enum/ppx_deriving_enum.cppo.ml
@@ -17,7 +17,7 @@ let constr_attr_value = attr_value Attribute.Context.constructor_declaration
 let rtag_attr_value = attr_value Attribute.Context.rtag
 
 let mappings_of_type type_decl =
-  let map acc mappings attr_value x attrs constr_name =
+  let map acc mappings attr_value x constr_name =
     let value =
       match Attribute.get attr_value x with
       | Some idx -> idx | None -> acc
@@ -32,7 +32,7 @@ let mappings_of_type type_decl =
           if pcd_args <> Pcstr_tuple([]) then
             raise_errorf ~loc:pcd_loc
                          "%s can be derived only for argumentless constructors" deriver;
-          map acc mappings constr_attr_value constr pcd_attributes pcd_name)
+          map acc mappings constr_attr_value constr pcd_name)
         (0, []) constrs
     | Ptype_abstract, Some { ptyp_desc = Ptyp_variant (constrs, Closed, None); ptyp_loc } ->
       `Polymorphic,
@@ -48,11 +48,10 @@ let mappings_of_type type_decl =
                          deriver
           in
           let loc = row_field.prf_loc in
-          let attrs = row_field.prf_attributes in
           match row_field.prf_desc with
           | Rinherit _ -> error_inherit loc
           | Rtag (name, true, []) ->
-            map acc mappings rtag_attr_value row_field attrs name
+            map acc mappings rtag_attr_value row_field name
           | Rtag _ -> error_arguments loc
 )
         (0, []) constrs

--- a/src_plugins/enum/ppx_deriving_enum.cppo.ml
+++ b/src_plugins/enum/ppx_deriving_enum.cppo.ml
@@ -11,11 +11,6 @@ module Stdlib = Pervasives
 let deriver = "enum"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let parse_options options =
-  options |> List.iter (fun (name, expr) ->
-    match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
-
 let attr_value attrs =
   Ppx_deriving.(attrs |> attr ~deriver "value" |> Arg.(get_attr ~deriver int))
 
@@ -77,8 +72,7 @@ let mappings_of_type type_decl =
   mappings |> List.stable_sort (fun (a,_) (b,_) -> Stdlib.compare a b) |> check_dup;
   kind, mappings
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ({ ptype_loc = loc } as type_decl) =
   let kind, mappings = mappings_of_type type_decl in
   let patt name =
     match kind with
@@ -106,9 +100,8 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
    Vb.mk (pvar (Ppx_deriving.mangle_type_decl (`Suffix "of_enum") type_decl))
          (Exp.function_ from_enum_cases)]
 
-let sig_of_type ~options ~path type_decl =
+let sig_of_type type_decl =
   let loc = type_decl.ptype_loc in
-  parse_options options;
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "min") type_decl))
              [%type: Ppx_deriving_runtime.int]);
@@ -119,12 +112,11 @@ let sig_of_type ~options ~path type_decl =
    Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Suffix "of_enum") type_decl))
              [%type: Ppx_deriving_runtime.int -> [%t typ] Ppx_deriving_runtime.option])]
 
-(* TODO: remove always [] ~options argument *)
-let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  [Str.value Nonrecursive (List.concat (List.map str_of_type type_decls))])
 
-let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =
   Deriving.add

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -207,6 +207,14 @@ let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decl
 let deriving: Deriving.t =
   Deriving.add
     deriver
-    ~extension:(fun ~loc:_ ~path:_ -> Ppx_deriving.with_quoter expr_of_typ)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
+
+(* custom extension such that "derive"-prefixed also works *)
+let derive_extension =
+  Extension.V3.declare "derive.eq" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> Ppx_deriving.with_quoter expr_of_typ)
+let derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -7,8 +7,7 @@ open Ppx_deriving.Ast_convenience
 let deriver = "eq"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.eq.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.eq.nobuiltin" Attribute.Context.core_type
 
 let ct_attr_equal = Attribute.declare "deriving.eq.equal" Attribute.Context.core_type
   Ast_pattern.(single_expr_payload __) (fun e -> e)

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -63,10 +63,7 @@ and expr_of_typ quoter typ =
     match typ with
     | [%type: _] -> [%expr fun _ _ -> true]
     | { ptyp_desc = Ptyp_constr _ } ->
-      let builtin = match Attribute.get ct_attr_nobuiltin typ with
-        | Some () -> false
-        | None -> true
-      in
+      let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
       begin match builtin, typ with
       | true, [%type: unit] ->
         [%expr fun (_:unit) (_:unit) -> true]

--- a/src_plugins/eq/ppx_deriving_eq.cppo.ml
+++ b/src_plugins/eq/ppx_deriving_eq.cppo.ml
@@ -7,11 +7,11 @@ open Ppx_deriving.Ast_convenience
 let deriver = "eq"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let attr_nobuiltin attrs =
-  Ppx_deriving.(attrs |> attr ~deriver "nobuiltin" |> Arg.get_flag ~deriver)
+let ct_attr_nobuiltin = Attribute.declare "deriving.eq.nobuiltin" Attribute.Context.core_type
+  Ast_pattern.(pstr nil) ()
 
-let attr_equal attrs =
-  Ppx_deriving.(attrs |> attr ~deriver "equal" |> Arg.(get_attr ~deriver expr))
+let ct_attr_equal = Attribute.declare "deriving.eq.equal" Attribute.Context.core_type
+  Ast_pattern.(single_expr_payload __) (fun e -> e)
 
 let argn kind =
   Printf.sprintf (match kind with `lhs -> "lhs%d" | `rhs -> "rhs%d")
@@ -58,13 +58,16 @@ and expr_of_typ quoter typ =
   let loc = !Ast_helper.default_loc in
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   let expr_of_typ = expr_of_typ quoter in
-  match attr_equal typ.ptyp_attributes with
+  match Attribute.get ct_attr_equal typ with
   | Some fn -> Ppx_deriving.quote ~quoter fn
   | None ->
     match typ with
     | [%type: _] -> [%expr fun _ _ -> true]
     | { ptyp_desc = Ptyp_constr _ } ->
-      let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
+      let builtin = match Attribute.get ct_attr_nobuiltin typ with
+        | Some () -> false
+        | None -> true
+      in
       begin match builtin, typ with
       | true, [%type: unit] ->
         [%expr fun (_:unit) (_:unit) -> true]

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -142,12 +142,16 @@ let sig_of_type ~options ~path type_decl =
   [Sig.value ~loc (Val.mk (mkloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl) loc)
               (polymorphize [%type: [%t acc] -> [%t typ] -> [%t acc]]))]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~core_type: expr_of_typ
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-      List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ)
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -147,6 +147,14 @@ let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decl
 let deriving: Deriving.t =
   Deriving.add
     deriver
-    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
+
+(* custom extension such that "derive"-prefixed also works *)
+let derive_extension =
+  Extension.V3.declare "derive.fold" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ)
+let derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -7,8 +7,7 @@ open Ppx_deriving.Ast_convenience
 let deriver = "fold"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.fold.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.fold.nobuiltin" Attribute.Context.core_type
 
 let argn = Printf.sprintf "a%d"
 let argl = Printf.sprintf "a%s"

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -27,10 +27,7 @@ let rec expr_of_typ typ =
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun acc _ -> acc]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
-    let builtin = match Attribute.get ct_attr_nobuiltin typ with
-      | Some () -> false
-      | None -> true
-    in
+    let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
     begin match builtin, typ with
     | true, [%type: [%t? typ] ref] -> [%expr fun acc x -> [%e expr_of_typ typ] acc !x]
     | true, [%type: [%t? typ] list] ->

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -7,11 +7,6 @@ open Ppx_deriving.Ast_convenience
 let deriver = "fold"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let parse_options options =
-  options |> List.iter (fun (name, expr) ->
-    match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
-
 let attr_nobuiltin attrs =
   Ppx_deriving.(attrs |> attr ~deriver "nobuiltin" |> Arg.get_flag ~deriver)
 
@@ -89,8 +84,7 @@ and expr_of_label_decl { pld_type; pld_attributes } =
   let attrs = pld_type.ptyp_attributes @ pld_attributes in
   expr_of_typ { pld_type with ptyp_attributes = attrs }
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ({ ptype_loc = loc } as type_decl) =
   let mapper =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest -> expr_of_typ manifest
@@ -128,8 +122,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
          (pvar (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl))
          (polymorphize mapper)]
 
-let sig_of_type ~options ~path type_decl =
-  parse_options options;
+let sig_of_type type_decl =
   let loc = type_decl.ptype_loc in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let vars =
@@ -142,12 +135,11 @@ let sig_of_type ~options ~path type_decl =
   [Sig.value ~loc (Val.mk (mkloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl) loc)
               (polymorphize [%type: [%t acc] -> [%t typ] -> [%t acc]]))]
 
-(* TODO: remove always [] ~options argument *)
-let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
-let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =
   Deriving.add

--- a/src_plugins/fold/ppx_deriving_fold.cppo.ml
+++ b/src_plugins/fold/ppx_deriving_fold.cppo.ml
@@ -7,8 +7,8 @@ open Ppx_deriving.Ast_convenience
 let deriver = "fold"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let attr_nobuiltin attrs =
-  Ppx_deriving.(attrs |> attr ~deriver "nobuiltin" |> Arg.get_flag ~deriver)
+let ct_attr_nobuiltin = Attribute.declare "deriving.fold.nobuiltin" Attribute.Context.core_type
+  Ast_pattern.(pstr nil) ()
 
 let argn = Printf.sprintf "a%d"
 let argl = Printf.sprintf "a%s"
@@ -28,7 +28,10 @@ let rec expr_of_typ typ =
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun acc _ -> acc]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
-    let builtin = not (attr_nobuiltin typ.ptyp_attributes) in
+    let builtin = match Attribute.get ct_attr_nobuiltin typ with
+      | Some () -> false
+      | None -> true
+    in
     begin match builtin, typ with
     | true, [%type: [%t? typ] ref] -> [%expr fun acc x -> [%e expr_of_typ typ] acc !x]
     | true, [%type: [%t? typ] list] ->

--- a/src_plugins/iter/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/iter/ppx_deriving_iter.cppo.ml
@@ -134,12 +134,16 @@ let sig_of_type ~options ~path type_decl =
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl))
               (polymorphize [%type: [%t typ] -> Ppx_deriving_runtime.unit]))]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~core_type: expr_of_typ
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-      List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ)
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/iter/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/iter/ppx_deriving_iter.cppo.ml
@@ -7,11 +7,6 @@ open Ppx_deriving.Ast_convenience
 let deriver = "iter"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let parse_options options =
-  options |> List.iter (fun (name, expr) ->
-    match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
-
 let attr_nobuiltin attrs =
   Ppx_deriving.(attrs |> attr ~deriver "nobuiltin" |> Arg.get_flag ~deriver)
 
@@ -84,8 +79,7 @@ and expr_of_label_decl { pld_type; pld_attributes } =
   let attrs = pld_type.ptyp_attributes @ pld_attributes in
   expr_of_typ { pld_type with ptyp_attributes = attrs }
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ({ ptype_loc = loc } as type_decl) =
   let iterator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest -> expr_of_typ manifest
@@ -125,21 +119,19 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
          (pvar (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl))
          (polymorphize iterator)]
 
-let sig_of_type ~options ~path type_decl =
+let sig_of_type type_decl =
   let loc = !Ast_helper.default_loc in
-  parse_options options;
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
                         (fun var -> [%type: [%t var] -> Ppx_deriving_runtime.unit]) type_decl in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl))
               (polymorphize [%type: [%t typ] -> Ppx_deriving_runtime.unit]))]
 
-(* TODO: remove always [] ~options argument *)
-let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
-let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =
   Deriving.add

--- a/src_plugins/iter/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/iter/ppx_deriving_iter.cppo.ml
@@ -139,6 +139,15 @@ let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decl
 let deriving: Deriving.t =
   Deriving.add
     deriver
-    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
+
+
+(* custom extension such that "derive"-prefixed also works *)
+let derive_extension =
+  Extension.V3.declare "derive.iter" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ)
+let derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/iter/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/iter/ppx_deriving_iter.cppo.ml
@@ -23,10 +23,7 @@ let rec expr_of_typ typ =
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun _ -> ()]
   | { ptyp_desc = Ptyp_constr _ } ->
-    let builtin = match Attribute.get ct_attr_nobuiltin typ with
-      | Some () -> false
-      | None -> true
-    in
+    let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
     begin match builtin, typ with
     | true, [%type: [%t? typ] ref] ->
       [%expr fun x -> [%e expr_of_typ typ] !x]

--- a/src_plugins/iter/ppx_deriving_iter.cppo.ml
+++ b/src_plugins/iter/ppx_deriving_iter.cppo.ml
@@ -7,8 +7,7 @@ open Ppx_deriving.Ast_convenience
 let deriver = "iter"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.iter.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.iter.nobuiltin" Attribute.Context.core_type
 
 let argn = Printf.sprintf "a%d"
 let argl = Printf.sprintf "a%s"

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -134,11 +134,15 @@ let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl)) typ)]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~type_decl_str: (fun ~options ~path type_decls ->
-       [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-       List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -7,16 +7,33 @@ open Ppx_deriving.Ast_convenience
 let deriver = "make"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let attr_default attrs =
-  Ppx_deriving.(attrs |> attr ~deriver "default" |> Arg.(get_attr ~deriver expr))
+let attr_default context = Attribute.declare "deriving.make.default" context
+  Ast_pattern.(single_expr_payload __) (fun e -> e)
+let ct_attr_default = attr_default Attribute.Context.core_type
+let label_attr_default = attr_default Attribute.Context.label_declaration
 
-let attr_split attrs =
-  Ppx_deriving.(attrs |> attr ~deriver "split" |> Arg.get_flag ~deriver)
+let attr_split context = Attribute.declare "deriving.make.split" context
+  Ast_pattern.(pstr nil) ()
+let ct_attr_split = attr_split Attribute.Context.core_type
+let label_attr_split = attr_split Attribute.Context.label_declaration
+
+let attr_main context = Attribute.declare "deriving.make.main" context
+  Ast_pattern.(pstr nil) ()
+let ct_attr_main = attr_main Attribute.Context.core_type
+let label_attr_main = attr_main Attribute.Context.label_declaration
+
+let attribute_get2 attr1 x1 attr2 x2 =
+  match Attribute.get attr1 x1, Attribute.get attr2 x2 with
+  | Some _ as y, _ -> y
+  | None, y -> y
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
-    if Ppx_deriving.(pld_type.ptyp_attributes @ pld_attributes |>
-                     attr ~deriver "main" |> Arg.get_flag ~deriver) then
+    let is_main = match attribute_get2 ct_attr_main pld_type label_attr_main label with
+      | Some () -> true
+      | None -> false
+    in
+    if is_main then
       match main with
       | Some _ -> raise_errorf ~loc:pld_loc "Duplicate [@deriving.%s.main] annotation" deriver
       | None -> Some label, labels
@@ -25,12 +42,15 @@ let find_main labels =
     (None, []) labels
 
 
-let is_optional { pld_name = { txt = name }; pld_type; pld_attributes } =
-  let attrs = pld_attributes @ pld_type.ptyp_attributes in
-  match attr_default attrs with
+let is_optional ({ pld_name = { txt = name }; pld_type; pld_attributes } as label) =
+  match attribute_get2 label_attr_default label ct_attr_default pld_type with
   | Some _ -> true
   | None ->
-    attr_split attrs ||
+    let split = match attribute_get2 label_attr_split label ct_attr_split pld_type with
+      | Some () -> true
+      | None -> false
+    in
+    split ||
     (match Ppx_deriving.remove_pervasives ~deriver pld_type with
      | [%type: [%t? _] list]
      | [%type: [%t? _] option] -> true
@@ -55,14 +75,17 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | None ->
           record fields
       in
-      List.fold_left (fun accum { pld_name = { txt = name }; pld_type; pld_attributes } ->
-        let attrs = pld_attributes @ pld_type.ptyp_attributes in
-        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        match attr_default attrs with
+      List.fold_left (fun accum ({ pld_name = { txt = name }; pld_type; pld_attributes } as label) ->
+        match attribute_get2 label_attr_default label ct_attr_default pld_type with
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
-        if attr_split attrs then
+        let split = match attribute_get2 label_attr_split label ct_attr_split pld_type with
+          | Some () -> true
+          | None -> false
+        in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
+        if split then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in
@@ -101,13 +124,16 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
         | None when has_option -> Typ.arrow Label.nolabel (tconstr "unit" []) typ
         | None -> typ
       in
-      List.fold_left (fun accum { pld_name = { txt = name; loc }; pld_type; pld_attributes } ->
-        let attrs = pld_type.ptyp_attributes @ pld_attributes in
-        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        match attr_default attrs with
+      List.fold_left (fun accum ({ pld_name = { txt = name; loc }; pld_type; pld_attributes } as label) ->
+        match attribute_get2 ct_attr_default pld_type label_attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
-        if attr_split attrs then
+        let split = match attribute_get2 ct_attr_split pld_type label_attr_split label with
+          | Some () -> true
+          | None -> false
+        in
+        let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
+        if split then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -27,8 +27,7 @@ let attribute_get2 attr1 x1 attr2 x2 =
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
-    let is_main = Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label in
-    if is_main then
+    if Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label then
       match main with
       | Some _ -> raise_errorf ~loc:pld_loc "Duplicate [@deriving.%s.main] annotation" deriver
       | None -> Some label, labels
@@ -41,8 +40,7 @@ let is_optional ({ pld_name = { txt = name }; pld_type; pld_attributes } as labe
   match attribute_get2 label_attr_default label ct_attr_default pld_type with
   | Some _ -> true
   | None ->
-    let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
-    split ||
+    Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type ||
     (match Ppx_deriving.remove_pervasives ~deriver pld_type with
      | [%type: [%t? _] list]
      | [%type: [%t? _] option] -> true
@@ -72,9 +70,8 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
-        let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        if split then
+        if Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in
@@ -117,9 +114,8 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
         match attribute_get2 ct_attr_default pld_type label_attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
-        let split = Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
-        if split then
+        if Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label then
           match pld_type with
           | [%type: [%t? lhs] * [%t? rhs] list] when name.[String.length name - 1] = 's' ->
             let name' = String.sub name 0 (String.length name - 1) in

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -27,10 +27,7 @@ let attribute_get2 attr1 x1 attr2 x2 =
 
 let find_main labels =
   List.fold_left (fun (main, labels) ({ pld_type; pld_loc; pld_attributes } as label) ->
-    let is_main = match attribute_get2 ct_attr_main pld_type label_attr_main label with
-      | Some () -> true
-      | None -> false
-    in
+    let is_main = Attribute.has_flag ct_attr_main pld_type || Attribute.has_flag label_attr_main label in
     if is_main then
       match main with
       | Some _ -> raise_errorf ~loc:pld_loc "Duplicate [@deriving.%s.main] annotation" deriver
@@ -44,10 +41,7 @@ let is_optional ({ pld_name = { txt = name }; pld_type; pld_attributes } as labe
   match attribute_get2 label_attr_default label ct_attr_default pld_type with
   | Some _ -> true
   | None ->
-    let split = match attribute_get2 label_attr_split label ct_attr_split pld_type with
-      | Some () -> true
-      | None -> false
-    in
+    let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
     split ||
     (match Ppx_deriving.remove_pervasives ~deriver pld_type with
      | [%type: [%t? _] list]
@@ -78,10 +72,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
         | None ->
-        let split = match attribute_get2 label_attr_split label ct_attr_split pld_type with
-          | Some () -> true
-          | None -> false
-        in
+        let split = Attribute.has_flag label_attr_split label || Attribute.has_flag ct_attr_split pld_type in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         if split then
           match pld_type with
@@ -126,10 +117,7 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
         match attribute_get2 ct_attr_default pld_type label_attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->
-        let split = match attribute_get2 ct_attr_split pld_type label_attr_split label with
-          | Some () -> true
-          | None -> false
-        in
+        let split = Attribute.has_flag ct_attr_split pld_type || Attribute.has_flag label_attr_split label in
         let pld_type = Ppx_deriving.remove_pervasives ~deriver pld_type in
         if split then
           match pld_type with

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -12,13 +12,11 @@ let attr_default context = Attribute.declare "deriving.make.default" context
 let ct_attr_default = attr_default Attribute.Context.core_type
 let label_attr_default = attr_default Attribute.Context.label_declaration
 
-let attr_split context = Attribute.declare "deriving.make.split" context
-  Ast_pattern.(pstr nil) ()
+let attr_split context = Attribute.declare_flag "deriving.make.split" context
 let ct_attr_split = attr_split Attribute.Context.core_type
 let label_attr_split = attr_split Attribute.Context.label_declaration
 
-let attr_main context = Attribute.declare "deriving.make.main" context
-  Ast_pattern.(pstr nil) ()
+let attr_main context = Attribute.declare_flag "deriving.make.main" context
 let ct_attr_main = attr_main Attribute.Context.core_type
 let label_attr_main = attr_main Attribute.Context.label_declaration
 

--- a/src_plugins/make/ppx_deriving_make.cppo.ml
+++ b/src_plugins/make/ppx_deriving_make.cppo.ml
@@ -7,11 +7,6 @@ open Ppx_deriving.Ast_convenience
 let deriver = "make"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let parse_options options =
-  options |> List.iter (fun (name, expr) ->
-    match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
-
 let attr_default attrs =
   Ppx_deriving.(attrs |> attr ~deriver "default" |> Arg.(get_attr ~deriver expr))
 
@@ -41,8 +36,7 @@ let is_optional { pld_name = { txt = name }; pld_type; pld_attributes } =
      | [%type: [%t? _] option] -> true
      | _ -> false)
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ({ ptype_loc = loc } as type_decl) =
   let quoter = Ppx_deriving.create_quoter () in
   let creator =
     match type_decl.ptype_kind with
@@ -93,8 +87,7 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
 let wrap_predef_option typ =
   typ
 
-let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let sig_of_type ({ ptype_loc = loc } as type_decl) =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let typ =
     match type_decl.ptype_kind with
@@ -134,12 +127,11 @@ let sig_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl)) typ)]
 
-(* TODO: remove always [] ~options argument *)
-let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  [Str.value Nonrecursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  [Str.value Nonrecursive (List.concat (List.map str_of_type type_decls))])
 
-let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =
   Deriving.add

--- a/src_plugins/map/ppx_deriving_map.cppo.ml
+++ b/src_plugins/map/ppx_deriving_map.cppo.ml
@@ -24,10 +24,7 @@ let rec expr_of_typ ?decl typ =
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr _ } ->
-    let builtin = match Attribute.get ct_attr_nobuiltin typ with
-      | Some () -> false
-      | None -> true
-    in
+    let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
     begin match builtin, typ with
     | true, [%type: [%t? typ] list] ->
       [%expr Ppx_deriving_runtime.List.map [%e expr_of_typ ?decl typ]]

--- a/src_plugins/map/ppx_deriving_map.cppo.ml
+++ b/src_plugins/map/ppx_deriving_map.cppo.ml
@@ -141,12 +141,16 @@ let sig_of_type ~options ~path type_decl =
   let typ = List.fold_right arrow poly_fns (arrow typ_arg typ_ret) in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl)) typ)]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~core_type: (expr_of_typ ?decl:None)
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-      List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ ?decl:None)
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/map/ppx_deriving_map.cppo.ml
+++ b/src_plugins/map/ppx_deriving_map.cppo.ml
@@ -149,3 +149,12 @@ let deriving: Deriving.t =
     ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ ?decl:None)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
+
+(* custom extension such that "derive"-prefixed also works *)
+let derive_extension =
+  Extension.V3.declare "derive.map" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ ?decl:None)
+let derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/map/ppx_deriving_map.cppo.ml
+++ b/src_plugins/map/ppx_deriving_map.cppo.ml
@@ -7,8 +7,7 @@ open Ppx_deriving.Ast_convenience
 let deriver = "map"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.map.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.map.nobuiltin" Attribute.Context.core_type
 
 let argn = Printf.sprintf "a%d"
 let argl = Printf.sprintf "a%s"

--- a/src_plugins/map/ppx_deriving_map.cppo.ml
+++ b/src_plugins/map/ppx_deriving_map.cppo.ml
@@ -142,7 +142,6 @@ let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decl
 let deriving: Deriving.t =
   Deriving.add
     deriver
-    ~extension:(fun ~loc:_ ~path:_ -> expr_of_typ ?decl:None)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
 

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -67,10 +67,7 @@ and expr_of_typ quoter typ =
     match typ with
     | [%type: _] -> [%expr fun _ _ -> 0]
     | { ptyp_desc = Ptyp_constr _ } ->
-      let builtin = match Attribute.get ct_attr_nobuiltin typ with
-        | Some () -> false
-        | None -> true
-      in
+      let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
       begin match builtin, typ with
       | true, [%type: _] ->
         [%expr fun _ _ -> 0]

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -8,8 +8,7 @@ open Ppx_deriving.Ast_convenience
 let deriver = "ord"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.ord.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.ord.nobuiltin" Attribute.Context.core_type
 
 let ct_attr_compare = Attribute.declare "deriving.ord.compare" Attribute.Context.core_type
   Ast_pattern.(single_expr_payload __) (fun e -> e)

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -239,12 +239,16 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
          (Pat.constraint_ out_var out_type)
          (Ppx_deriving.sanitize ~quoter (eta_expand (polymorphize comparator)))]
 
-let () =
-  Ppx_deriving.(register (create deriver
-    ~core_type: (Ppx_deriving.with_quoter expr_of_typ)
-    ~type_decl_str: (fun ~options ~path type_decls ->
-      [Str.value Recursive (List.concat (List.map (str_of_type ~options ~path) type_decls))])
-    ~type_decl_sig: (fun ~options ~path type_decls ->
-      List.concat (List.map (sig_of_type ~options ~path) type_decls))
-    ()
-  ))
+(* TODO: remove always [] ~options argument *)
+let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+
+let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
+  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+
+let deriving: Deriving.t =
+  Deriving.add
+    deriver
+    ~extension:(fun ~loc:_ ~path:_ -> Ppx_deriving.with_quoter expr_of_typ)
+    ~str_type_decl:impl_generator
+    ~sig_type_decl:intf_generator

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -244,6 +244,14 @@ let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decl
 let deriving: Deriving.t =
   Deriving.add
     deriver
-    ~extension:(fun ~loc:_ ~path:_ -> Ppx_deriving.with_quoter expr_of_typ)
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
+
+(* custom extension such that "derive"-prefixed also works *)
+let derive_extension =
+  Extension.V3.declare "derive.ord" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> Ppx_deriving.with_quoter expr_of_typ)
+let derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/ord/ppx_deriving_ord.cppo.ml
+++ b/src_plugins/ord/ppx_deriving_ord.cppo.ml
@@ -8,11 +8,6 @@ open Ppx_deriving.Ast_convenience
 let deriver = "ord"
 let raise_errorf = Ppx_deriving.raise_errorf
 
-let parse_options options =
-  options |> List.iter (fun (name, expr) ->
-    match name with
-    | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name)
-
 let attr_nobuiltin attrs =
   Ppx_deriving.(attrs |> attr ~deriver "nobuiltin" |> Arg.get_flag ~deriver)
 
@@ -170,20 +165,18 @@ and expr_of_typ quoter typ =
       raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                    deriver (Ppx_deriving.string_of_core_type typ)
 
-let core_type_of_decl ~options ~path type_decl =
-  parse_options options;
+let core_type_of_decl type_decl =
   let loc = type_decl.ptype_loc in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
           (fun var -> [%type: [%t var] -> [%t var] -> Ppx_deriving_runtime.int]) type_decl in
   (polymorphize [%type: [%t typ] -> [%t typ] -> Ppx_deriving_runtime.int])
 
-let sig_of_type ~options ~path type_decl =
+let sig_of_type type_decl =
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl))
-             (core_type_of_decl ~options ~path type_decl))]
+             (core_type_of_decl type_decl))]
 
-let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  parse_options options;
+let str_of_type ({ ptype_loc = loc } as type_decl) =
   let quoter = Ppx_deriving.create_quoter () in
   let comparator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
@@ -232,19 +225,18 @@ let str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   in
   let out_type =
     Ppx_deriving.strong_type_of_type @@
-      core_type_of_decl ~options ~path type_decl in
+      core_type_of_decl type_decl in
   let out_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "compare") type_decl) in
   [Vb.mk ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]]
          (Pat.constraint_ out_var out_type)
          (Ppx_deriving.sanitize ~quoter (eta_expand (polymorphize comparator)))]
 
-(* TODO: remove always [] ~options argument *)
-let impl_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  [Str.value Recursive (List.concat (List.map (str_of_type ~options:[] ~path) type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
-let intf_generator = Deriving.Generator.make_noarg (fun ~loc:_ ~path (_, type_decls) ->
-  List.concat (List.map (sig_of_type ~options:[] ~path) type_decls))
+let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+  List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =
   Deriving.add

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -318,10 +318,10 @@ let ebool: _ Ast_pattern.t -> _ Ast_pattern.t =
     | [%expr true] -> true
     | [%expr false] -> false
     | _ -> Location.raise_errorf ~loc "with_path should be a boolean")
-let args () = Deriving.Args.(empty +> arg "with_path" (ebool __))
+let args = Deriving.Args.(empty +> arg "with_path" (ebool __))
 (* TODO: add arg_default to ppxlib? *)
 
-let impl_generator = Deriving.Generator.V2.make (args ()) (fun ~ctxt (_, type_decls) with_path ->
+let impl_generator = Deriving.Generator.V2.make args (fun ~ctxt (_, type_decls) with_path ->
   let path =
     let code_path = Expansion_context.Deriver.code_path ctxt in
     (* Cannot use main_module_name from code_path because that contains .cppo suffix (via line directives), so it's actually not the module name. *)

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -70,8 +70,7 @@ let rec expr_of_typ quoter typ =
   match Attribute.get ct_attr_printer typ with
   | Some printer -> [%expr [%e wrap_printer quoter printer] fmt]
   | None ->
-  let opaque = Attribute.has_flag ct_attr_opaque typ in
-  if opaque then
+  if Attribute.has_flag ct_attr_opaque typ then
     [%expr fun _ -> Ppx_deriving_runtime.Format.pp_print_string fmt "<opaque>"]
   else
     let format x = [%expr Ppx_deriving_runtime.Format.fprintf fmt [%e str x]] in

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -17,8 +17,7 @@ let expand_path ~with_path ~path name =
   let path = if with_path then path else [] in
   Ppx_deriving.expand_path ~path name
 
-let ct_attr_nobuiltin = Attribute.declare "deriving.show.nobuiltin" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_nobuiltin = Attribute.declare_flag "deriving.show.nobuiltin" Attribute.Context.core_type
 
 let attr_printer context = Attribute.declare "deriving.show.printer" context
   Ast_pattern.(single_expr_payload __) (fun e -> e)
@@ -28,8 +27,7 @@ let constr_attr_printer = attr_printer Attribute.Context.constructor_declaration
 let ct_attr_polyprinter = Attribute.declare "deriving.show.polyprinter" Attribute.Context.core_type
   Ast_pattern.(single_expr_payload __) (fun e -> e)
 
-let ct_attr_opaque = Attribute.declare "deriving.show.opaque" Attribute.Context.core_type
-  Ast_pattern.(pstr nil) ()
+let ct_attr_opaque = Attribute.declare_flag "deriving.show.opaque" Attribute.Context.core_type
 
 let argn = Printf.sprintf "a%d"
 let argl = Printf.sprintf "a%s"

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -314,10 +314,10 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
 
 (* TODO: add to ppxlib? *)
 let ebool: _ Ast_pattern.t -> _ Ast_pattern.t =
-  Ast_pattern.map1 ~f:(function
+  Ast_pattern.map1' ~f:(fun loc -> function
     | [%expr true] -> true
     | [%expr false] -> false
-    | _ -> failwith "not bool")
+    | _ -> Location.raise_errorf ~loc "with_path should be a boolean")
 let args () = Deriving.Args.(empty +> arg "with_path" (ebool __))
 (* TODO: add arg_default to ppxlib? *)
 

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -70,10 +70,7 @@ let rec expr_of_typ quoter typ =
   match Attribute.get ct_attr_printer typ with
   | Some printer -> [%expr [%e wrap_printer quoter printer] fmt]
   | None ->
-  let opaque = match Attribute.get ct_attr_opaque typ with
-    | Some () -> true
-    | None -> false
-  in
+  let opaque = Attribute.has_flag ct_attr_opaque typ in
   if opaque then
     [%expr fun _ -> Ppx_deriving_runtime.Format.pp_print_string fmt "<opaque>"]
   else
@@ -92,10 +89,7 @@ let rec expr_of_typ quoter typ =
     | { ptyp_desc = Ptyp_arrow _ } ->
       [%expr fun _ -> Ppx_deriving_runtime.Format.pp_print_string fmt "<fun>"]
     | { ptyp_desc = Ptyp_constr _ } ->
-      let builtin = match Attribute.get ct_attr_nobuiltin typ with
-        | Some () -> false
-        | None -> true
-      in
+      let builtin = not (Attribute.has_flag ct_attr_nobuiltin typ) in
       begin match builtin, typ with
       | true, [%type: unit]        -> [%expr fun () -> Ppx_deriving_runtime.Format.pp_print_string fmt "()"]
       | true, [%type: int]         -> format "%d"

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -314,10 +314,10 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
 
 (* TODO: add to ppxlib? *)
 let ebool: _ Ast_pattern.t -> _ Ast_pattern.t =
-  Ast_pattern.map1 ~f:(fun e ->
-    match Ppx_deriving.Arg.bool e with
-    | Ok b -> b
-    | Error _ -> failwith "not bool")
+  Ast_pattern.map1 ~f:(function
+    | [%expr true] -> true
+    | [%expr false] -> false
+    | _ -> failwith "not bool")
 let args () = Deriving.Args.(empty +> arg "with_path" (ebool __))
 (* TODO: add arg_default to ppxlib? *)
 

--- a/src_plugins/show/ppx_deriving_show.cppo.ml
+++ b/src_plugins/show/ppx_deriving_show.cppo.ml
@@ -312,13 +312,7 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
          (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter));
    Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
 
-(* TODO: add to ppxlib? *)
-let ebool: _ Ast_pattern.t -> _ Ast_pattern.t =
-  Ast_pattern.map1' ~f:(fun loc -> function
-    | [%expr true] -> true
-    | [%expr false] -> false
-    | _ -> Location.raise_errorf ~loc "with_path should be a boolean")
-let args = Deriving.Args.(empty +> arg "with_path" (ebool __))
+let args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
 (* TODO: add arg_default to ppxlib? *)
 
 let impl_generator = Deriving.Generator.V2.make args (fun ~ctxt (_, type_decls) with_path ->

--- a/src_test/deriving/test_ppx_deriving.ml
+++ b/src_test/deriving/test_ppx_deriving.ml
@@ -1,7 +1,7 @@
 open OUnit2
 
 let test_inline ctxt =
-  let sort = List.sort [%ord: int * int] in (* TODO: support derive.org again *)
+  let sort = List.sort [%ord: int * int] in (* TODO: support derive.ord again *)
   assert_equal ~printer:[%show: (int * int) list] (* TODO: support derive.show again *)
                [(1,1);(2,0);(3,5)] (sort [(2,0);(3,5);(1,1)])
 

--- a/src_test/deriving/test_ppx_deriving.ml
+++ b/src_test/deriving/test_ppx_deriving.ml
@@ -9,7 +9,7 @@ let test_inline_shorthand ctxt =
   assert_equal ~printer:(fun x -> x)
                "[(1, 1); (2, 0)]" ([%show: (int * int) list] [(1,1); (2,0)])
 
-(* TODO: how did this work and why did it break now? *)
+(* TODO: optional is incompatible with ppxlib derivers: https://github.com/ocaml-ppx/ppx_deriving/issues/247 *)
 (* type optional_deriver = string
 [@@deriving missing { optional = true }] *)
 

--- a/src_test/deriving/test_ppx_deriving.ml
+++ b/src_test/deriving/test_ppx_deriving.ml
@@ -1,16 +1,17 @@
 open OUnit2
 
 let test_inline ctxt =
-  let sort = List.sort [%derive.ord: int * int] in
-  assert_equal ~printer:[%derive.show: (int * int) list]
+  let sort = List.sort [%ord: int * int] in (* TODO: support derive.org again *)
+  assert_equal ~printer:[%show: (int * int) list] (* TODO: support derive.show again *)
                [(1,1);(2,0);(3,5)] (sort [(2,0);(3,5);(1,1)])
 
 let test_inline_shorthand ctxt =
   assert_equal ~printer:(fun x -> x)
                "[(1, 1); (2, 0)]" ([%show: (int * int) list] [(1,1); (2,0)])
 
-type optional_deriver = string
-[@@deriving missing { optional = true }]
+(* TODO: how did this work and why did it break now? *)
+(* type optional_deriver = string
+[@@deriving missing { optional = true }] *)
 
 type prefix = {
   field : int [@deriving.eq.compare fun _ _ -> true]

--- a/src_test/deriving/test_ppx_deriving.ml
+++ b/src_test/deriving/test_ppx_deriving.ml
@@ -1,8 +1,8 @@
 open OUnit2
 
 let test_inline ctxt =
-  let sort = List.sort [%ord: int * int] in (* TODO: support derive.ord again *)
-  assert_equal ~printer:[%show: (int * int) list] (* TODO: support derive.show again *)
+  let sort = List.sort [%derive.ord: int * int] in
+  assert_equal ~printer:[%derive.show: (int * int) list]
                [(1,1);(2,0);(3,5)] (sort [(2,0);(3,5);(1,1)])
 
 let test_inline_shorthand ctxt =


### PR DESCRIPTION
This realizes part of #250:
1. All the standard deriving plugins defined here are switched to register themselves directly with ppxlib and declare their attributes directly with ppxlib.
2. ~~Deprecates only parts of ppx_deriving API, namely ppx_deriving deriver registration and attribute support. All the other utility functions remain undeprecated since many are still missing from ppxlib (https://github.com/ocaml-ppx/ppxlib/issues/317).~~
3. Delegates ppx_deriving quoter to ppxlib quoter.

Notably, this makes `[@@deriving_inline ...]` work on these standard derivers.

### TODO
- [x] Re-add `derive.*` extensions support?
- [ ] Fix missing optional derivers support? Separate issue really: #247.