### PR TITLE
Deprecate `Ppx_deriving.register`

### DIFF
--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -44,6 +44,7 @@ type deriver = {
 
 (** [register deriver] registers [deriver] according to its [name] field. *)
 val register : deriver -> unit
+[@@deprecated]
 
 (** [add_register_hook hook] adds [hook] to be executed whenever a new deriver
     is registered. *)


### PR DESCRIPTION
Added a deprecation signature to <https://github.com/ocaml-ppx/ppx_deriving/edit/master/src/api/ppx_deriving.cppo.mli#L48>.
 Sir @panglesd, please let me know if the modifications I am doing is not right. Though, I find it difficult to locate the exact lines of code to modify as supposed to <https://github.com/roddyyaga/ppx_rapper/issues/29>. 
Signed-off-by: Mario <66856309+marrious11@users.noreply.github.com>