### PR TITLE
Add missing cppo 1.1.0 lower bound

### DIFF
--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.6.3"}
-  "cppo" {build}
+  "cppo" {>= "1.1.0" & build}
   "ocamlfind"
   "ppx_derivers"
   "ppxlib" {>= "0.20.0"}


### PR DESCRIPTION
In #263 I noticed the experimental lower-bounds job in opam-ci failing with
```
/home/opam/.opam/4.05/bin/cppo: unknown option '-V'.
```
This adds the corresponding cppo lower bound.