### PR TITLE
Add missing unreleased CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@
   #263
   (Simmo Saan)
 
-* Introduce `Ppx_deriving_runtime.Stdlib` with OCaml >= 4.07. This module
-  already exists in OCaml < 4.07 but was missing otherwise.
+* Optimize forwarding in eq and ord plugins
+  #252
+  (Simmo Saan)
+
+* Delegate quoter to ppxlib
+  #263
+  (Simmo Saan)
+
+* Introduce `Ppx_deriving_runtime.Stdlib` with OCaml >= 4.07.
+  This module already exists in OCaml < 4.07 but was missing otherwise.
+  #258
+  (Kate Deplaix)
 
 5.2.1 (02/02/2021)
 ------------------


### PR DESCRIPTION
Since #263 is finally merged and #252 is also unreleased, it would be great to have a new release over 3 years. I suppose version 5.3 would make sense. Although #263 is a big internal change, it shouldn't be breaking (hopefully), but we'll see from opam-repository CI.
An eventual version 6.0 could be the actual deprecation of ppx_deriving API (#250), but there are still things to move over (https://github.com/ocaml-ppx/ppxlib/issues/317).

This PR is just an update of the unreleased CHANGELOG.