### PR TITLE
Declare `show`'s `with_path` argument for interface deriver as well

### DIFF
--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -330,7 +330,7 @@ let impl_generator = Deriving.Generator.V2.make args (fun ~ctxt (_, type_decls) 
   in
   [Str.value Recursive (List.concat (List.map (str_of_type ~with_path ~path) type_decls))])
 
-let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+let intf_generator = Deriving.Generator.V2.make args (fun ~ctxt:_ (_, type_decls) _with_path ->
   List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -303,10 +303,10 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
          (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter));
    Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
 
-let args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
+let impl_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
 (* TODO: add arg_default to ppxlib? *)
 
-let impl_generator = Deriving.Generator.V2.make args (fun ~ctxt (_, type_decls) with_path ->
+let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (_, type_decls) with_path ->
   let path =
     let code_path = Expansion_context.Deriver.code_path ctxt in
     (* Cannot use main_module_name from code_path because that contains .cppo suffix (via line directives), so it's actually not the module name. *)
@@ -330,7 +330,9 @@ let impl_generator = Deriving.Generator.V2.make args (fun ~ctxt (_, type_decls) 
   in
   [Str.value Recursive (List.concat (List.map (str_of_type ~with_path ~path) type_decls))])
 
-let intf_generator = Deriving.Generator.V2.make args (fun ~ctxt:_ (_, type_decls) _with_path ->
+let intf_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
+
+let intf_generator = Deriving.Generator.V2.make intf_args (fun ~ctxt:_ (_, type_decls) _with_path ->
   List.concat (List.map sig_of_type type_decls))
 
 let deriving: Deriving.t =


### PR DESCRIPTION
Even though the argument is unused in `.mli` files as it only affects the implementation and not the signature of the function, it used to be accepted back when declared via `ppx_deriving.api` so we need to keep it that way for compatibility.