### PR TITLE
Remove extensions from fold, iter and map plugins

### DIFF
--- a/src_plugins/fold/ppx_deriving_fold.ml
+++ b/src_plugins/fold/ppx_deriving_fold.ml
@@ -145,12 +145,3 @@ let deriving: Deriving.t =
     deriver
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
-
-(* custom extension such that "derive"-prefixed also works *)
-let derive_extension =
-  Extension.V3.declare "derive.fold" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ)
-let derive_transformation =
-  Driver.register_transformation
-    deriver
-    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -137,13 +137,3 @@ let deriving: Deriving.t =
     deriver
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
-
-
-(* custom extension such that "derive"-prefixed also works *)
-let derive_extension =
-  Extension.V3.declare "derive.iter" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ)
-let derive_transformation =
-  Driver.register_transformation
-    deriver
-    ~rules:[Context_free.Rule.extension derive_extension]

--- a/src_plugins/map/ppx_deriving_map.ml
+++ b/src_plugins/map/ppx_deriving_map.ml
@@ -144,12 +144,3 @@ let deriving: Deriving.t =
     deriver
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
-
-(* custom extension such that "derive"-prefixed also works *)
-let derive_extension =
-  Extension.V3.declare "derive.map" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> expr_of_typ ?decl:None)
-let derive_transformation =
-  Driver.register_transformation
-    deriver
-    ~rules:[Context_free.Rule.extension derive_extension]


### PR DESCRIPTION
These don't seem very useful:
1. On types without free variables, they're just identity.
2. On types with free variables, they require specially-named `poly_` functions present in the scope. These are usually declared at the type declaration level of the deriver.

These also appear to be unused according to sherlocode (we'll see about opam-repository CI...).

Removing map avoids a superficial conflict with ppx_let: https://github.com/janestreet/ppx_let/issues/14.

Of course, the morally right thing would be to declare a conflict with ppx_let for now and remove the conflict once ppx_let prefixes their extension. However, that would likely be inconvenient for many and for practical backwards-compatibility it's easier to remove something which doesn't seem to be used.