### PR TITLE
drop the `result` compatibility package dependency

### DIFF
--- a/ppx_deriving.opam
+++ b/ppx_deriving.opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlfind"
   "ppx_derivers"
   "ppxlib" {>= "0.32.0"}
-  "result"
   "ounit2" {with-test}
 ]
 synopsis: "Type-driven code generation for OCaml"

--- a/src/api/dune
+++ b/src/api/dune
@@ -5,11 +5,7 @@
  (preprocess (pps ppxlib.metaquot))
  (wrapped false)
  (ppx_runtime_libraries ppx_deriving_runtime)
- (libraries
-   compiler-libs.common
-   ppxlib
-   result
-   ppx_derivers))
+ (libraries compiler-libs.common ppxlib ppx_derivers))
 
 (rule
  (deps ppx_deriving.cppo.ml)

--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -232,9 +232,8 @@ let string_of_expression_opt (e : Parsetree.expression) : string option =
   | _ -> None
 
 module Arg = struct
-  type 'a conv = expression -> ('a, string) Result.result
+  type 'a conv = expression -> ('a, string) result
 
-  open Result
   let expr expr = Ok expr
 
   let int expr =

--- a/src/api/ppx_deriving.cppo.mli
+++ b/src/api/ppx_deriving.cppo.mli
@@ -104,37 +104,37 @@ module Arg : sig
   (** A type of conversion functions.
 
       A conversion function of type ['a conv] converts a raw expression into an
-      argument of type ['a]. Or returns [Result.Error "error"] if conversion
+      argument of type ['a]. Or returns [Error "error"] if conversion
       fails. *)
-  type 'a conv = expression -> ('a, string) Result.result
+  type 'a conv = expression -> ('a, string) result
 
   (** [expr] returns the input expression as-is. *)
   val expr : expression conv
 
   (** [bool expr] extracts a boolean constant from [expr], or returns
-      [Result.Error "boolean"] if [expr] does not contain a boolean literal. *)
+      [Error "boolean"] if [expr] does not contain a boolean literal. *)
   val bool : bool conv
 
   (** [int expr] extracts an integer constant from [expr], or returns
-      [Result.Error "integer"] if [expr] does not contain an integer literal. *)
+      [Error "integer"] if [expr] does not contain an integer literal. *)
   val int : int conv
 
   (** [string expr] extracts a string constant from [expr], or returns
-      [Result.Error "string"] if [expr] does not contain a string literal. *)
+      [Error "string"] if [expr] does not contain a string literal. *)
   val string : string conv
 
   (** [char expr] extracts a char constant from [expr], or returns
-      [Result.Error "char"] if [expr] does not contain a char literal. *)
+      [Error "char"] if [expr] does not contain a char literal. *)
   val char : char conv
 
   (** [enum values expr] extracts a polymorphic variant constant from [expr],
-      or returns [Result.Error "one of: `a, `b, ..."] if [expr] does not
+      or returns [Error "one of: `a, `b, ..."] if [expr] does not
       contain a polymorphic variant constructor included in [values]. *)
   val enum : string list -> string conv
 
   (** [list f expr] extracts a list constant from [expr] and maps every element
-      through [f], or returns [Result.Error "list:..."] where [...] is the
-      error returned by [f], or returns [Result.Error "list"] if [expr] does
+      through [f], or returns [Error "list:..."] where [...] is the
+      error returned by [f], or returns [Error "list"] if [expr] does
       not contain a list. *)
   val list : 'a conv -> 'a list conv
 

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -2,8 +2,7 @@
  (name ppx_deriving_runtime)
  (public_name ppx_deriving.runtime)
  (wrapped false)
- (synopsis "Type-driven code generation")
- (libraries result))
+ (synopsis "Type-driven code generation"))
 
 (rule
  (deps ppx_deriving_runtime.cppo.ml)

--- a/src/runtime/ppx_deriving_runtime.cppo.ml
+++ b/src/runtime/ppx_deriving_runtime.cppo.ml
@@ -24,15 +24,6 @@ module Stdlib = Stdlib
 
 include Stdlib
 
-module Result = struct
-  type ('a, 'b) t = ('a, 'b) result =
-    | Ok of 'a
-    | Error of 'b
-
-  type ('a, 'b) result = ('a, 'b) t =
-    | Ok of 'a
-    | Error of 'b
-end
 #else
 module Pervasives = Pervasives
 module Stdlib = Pervasives
@@ -58,18 +49,6 @@ module Weak = Weak
 module Printf = Printf
 module Format = Format
 module Buffer = Buffer
-module Result = struct
-  (* the "result" compatibility module defines Result.result,
-     not Result.t as the 4.08 stdlib *)
-  type ('a, 'b) t = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
-
-  (* ... and we also expose Result.result for backward-compatibility *)
-  type ('a, 'b) result = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
-end
 module Option = struct
   type 'a t = 'a option
 

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -28,18 +28,6 @@ include module type of struct
 end
 
 module Stdlib = Stdlib
-
-module Result : sig
-  type ('a, 'b) t = ('a, 'b) result =
-    | Ok of 'a
-    | Error of 'b
-
-  (* we also expose Result.result for backward-compatibility
-     with the Result package! *)
-  type ('a, 'b) result = ('a, 'b) t =
-    | Ok of 'a
-    | Error of 'b
-end
 #else
 module Pervasives = Pervasives
 
@@ -70,17 +58,6 @@ module Weak = Weak
 module Printf = Printf
 module Format = Format
 module Buffer = Buffer
-
-module Result : sig
-  type ('a, 'b) t = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
-
-  (* we also expose Result.result for backward-compatibility *)
-  type ('a, 'b) result = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
-end
 
 module Option : sig
   type 'a t = 'a option

--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -94,11 +94,11 @@ and expr_of_typ quoter typ =
           | Some a, Some b -> [%e expr_of_typ typ] a b
           | _ -> false]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
         [%expr fun x y ->
           match x, y with
-          | Result.Ok a, Result.Ok b -> [%e expr_of_typ ok_t] a b
-          | Result.Error a, Result.Error b -> [%e expr_of_typ err_t] a b
+          | Ok a, Ok b -> [%e expr_of_typ ok_t] a b
+          | Error a, Error b -> [%e expr_of_typ err_t] a b
           | _ -> false]
       | true, ([%type: [%t? typ] lazy_t] | [%type: [%t? typ] Lazy.t]) ->
         [%expr fun (lazy x) (lazy y) -> [%e expr_of_typ typ] x y]

--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -94,7 +94,7 @@ and expr_of_typ quoter typ =
           | Some a, Some b -> [%e expr_of_typ typ] a b
           | _ -> false]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr fun x y ->
           match x, y with
           | Ok a, Ok b -> [%e expr_of_typ ok_t] a b

--- a/src_plugins/fold/ppx_deriving_fold.ml
+++ b/src_plugins/fold/ppx_deriving_fold.ml
@@ -37,11 +37,11 @@ let rec expr_of_typ typ =
     | true, [%type: [%t? typ] option] ->
       [%expr fun acc -> function None -> acc | Some x -> [%e expr_of_typ typ] acc x]
     | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
+             [%type: ([%t? ok_t], [%t? err_t]) result]) ->
       [%expr
         fun acc -> function
-        | Result.Ok ok -> [%e expr_of_typ ok_t] acc ok
-        | Result.Error err -> [%e expr_of_typ err_t] acc err]
+        | Ok ok -> [%e expr_of_typ ok_t] acc ok
+        | Error err -> [%e expr_of_typ err_t] acc err]
     | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
       app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix deriver) lid)))
           (List.map expr_of_typ args)

--- a/src_plugins/fold/ppx_deriving_fold.ml
+++ b/src_plugins/fold/ppx_deriving_fold.ml
@@ -37,7 +37,7 @@ let rec expr_of_typ typ =
     | true, [%type: [%t? typ] option] ->
       [%expr fun acc -> function None -> acc | Some x -> [%e expr_of_typ typ] acc x]
     | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-             [%type: ([%t? ok_t], [%t? err_t]) result]) ->
+             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
       [%expr
         fun acc -> function
         | Ok ok -> [%e expr_of_typ ok_t] acc ok

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -33,7 +33,8 @@ let rec expr_of_typ typ =
       [%expr Ppx_deriving_runtime.Array.iter [%e expr_of_typ typ]]
     | true, [%type: [%t? typ] option] ->
       [%expr function None -> () | Some x -> [%e expr_of_typ typ] x]
-    | true, [%type: ([%t? ok_t], [%t? err_t]) result] ->
+    | true, [%type: ([%t? ok_t], [%t? err_t]) result]
+    | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
       [%expr
         function
         | Ok ok -> ignore ([%e expr_of_typ ok_t] ok)

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -33,11 +33,11 @@ let rec expr_of_typ typ =
       [%expr Ppx_deriving_runtime.Array.iter [%e expr_of_typ typ]]
     | true, [%type: [%t? typ] option] ->
       [%expr function None -> () | Some x -> [%e expr_of_typ typ] x]
-    | true, [%type: ([%t? ok_t], [%t? err_t]) Result.result] ->
+    | true, [%type: ([%t? ok_t], [%t? err_t]) result] ->
       [%expr
         function
-        | Result.Ok ok -> ignore ([%e expr_of_typ ok_t] ok)
-        | Result.Error err -> ignore ([%e expr_of_typ err_t] err)]
+        | Ok ok -> ignore ([%e expr_of_typ ok_t] ok)
+        | Error err -> ignore ([%e expr_of_typ err_t] err)]
     | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
       app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix deriver) lid)))
           (List.map expr_of_typ args)

--- a/src_plugins/map/ppx_deriving_map.ml
+++ b/src_plugins/map/ppx_deriving_map.ml
@@ -33,11 +33,11 @@ let rec expr_of_typ ?decl typ =
     | true, [%type: [%t? typ] option] ->
       [%expr function None -> None | Some x -> Some ([%e expr_of_typ ?decl typ] x)]
     | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
+             [%type: ([%t? ok_t], [%t? err_t]) result]) ->
       [%expr
         function
-        | Result.Ok ok -> Result.Ok ([%e expr_of_typ ?decl ok_t] ok)
-        | Result.Error err -> Result.Error ([%e expr_of_typ ?decl err_t] err)]
+        | Ok ok -> Ok ([%e expr_of_typ ?decl ok_t] ok)
+        | Error err -> Error ([%e expr_of_typ ?decl err_t] err)]
     | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
       app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Prefix deriver) lid)))
           (List.map (expr_of_typ ?decl) args)

--- a/src_plugins/map/ppx_deriving_map.ml
+++ b/src_plugins/map/ppx_deriving_map.ml
@@ -33,7 +33,7 @@ let rec expr_of_typ ?decl typ =
     | true, [%type: [%t? typ] option] ->
       [%expr function None -> None | Some x -> Some ([%e expr_of_typ ?decl typ] x)]
     | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-             [%type: ([%t? ok_t], [%t? err_t]) result]) ->
+             [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
       [%expr
         function
         | Ok ok -> Ok ([%e expr_of_typ ?decl ok_t] ok)

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -108,7 +108,7 @@ and expr_of_typ quoter typ =
           | None, Some _ -> -1
           | Some _, None -> 1]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr fun x y ->
           match x, y with
           | Error a, Error b -> [%e expr_of_typ err_t] a b

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -108,13 +108,13 @@ and expr_of_typ quoter typ =
           | None, Some _ -> -1
           | Some _, None -> 1]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
         [%expr fun x y ->
           match x, y with
-          | Result.Error a, Result.Error b -> [%e expr_of_typ err_t] a b
-          | Result.Ok a, Result.Ok b -> [%e expr_of_typ ok_t] a b
-          | Result.Ok _ , Result.Error _ -> -1
-          | Result.Error _ , Result.Ok _ -> 1]
+          | Error a, Error b -> [%e expr_of_typ err_t] a b
+          | Ok a, Ok b -> [%e expr_of_typ ok_t] a b
+          | Ok _ , Error _ -> -1
+          | Error _ , Ok _ -> 1]
       | true, ([%type: [%t? typ] lazy_t] | [%type: [%t? typ] Lazy.t]) ->
         [%expr fun (lazy x) (lazy y) -> [%e expr_of_typ typ] x y]
       | _, { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -122,7 +122,7 @@ let rec expr_of_typ quoter typ =
             [%e expr_of_typ typ] x;
             Ppx_deriving_runtime.Format.pp_print_string fmt ")"]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
         [%expr
           function
           | Ok ok ->

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -122,14 +122,14 @@ let rec expr_of_typ quoter typ =
             [%e expr_of_typ typ] x;
             Ppx_deriving_runtime.Format.pp_print_string fmt ")"]
       | true, ([%type: ([%t? ok_t], [%t? err_t]) result] |
-               [%type: ([%t? ok_t], [%t? err_t]) Result.result]) ->
+               [%type: ([%t? ok_t], [%t? err_t]) result]) ->
         [%expr
           function
-          | Result.Ok ok ->
+          | Ok ok ->
             Ppx_deriving_runtime.Format.pp_print_string fmt "(Ok ";
             [%e expr_of_typ ok_t] ok;
             Ppx_deriving_runtime.Format.pp_print_string fmt ")"
-          | Result.Error e ->
+          | Error e ->
             Ppx_deriving_runtime.Format.pp_print_string fmt "(Error ";
             [%e expr_of_typ err_t] e;
             Ppx_deriving_runtime.Format.pp_print_string fmt ")"]

--- a/src_test/eq/test_deriving_eq.cppo.ml
+++ b/src_test/eq/test_deriving_eq.cppo.ml
@@ -142,7 +142,6 @@ let test_result ctxt =
   assert_equal ~printer false (eq (Error 123) (Error 0))
 
 let test_result_result ctxt =
-  let open Result in
   let eq = [%eq: (string, int) result] in
   assert_equal ~printer true (eq (Ok "ttt") (Ok "ttt"));
   assert_equal ~printer false (eq (Ok "123") (Error 123));

--- a/src_test/fold/test_deriving_fold.cppo.ml
+++ b/src_test/fold/test_deriving_fold.cppo.ml
@@ -27,12 +27,12 @@ let test_result ctxt =
   assert_equal ~printer:string_of_int 1 (f 0 (Ok 1));
   assert_equal ~printer:string_of_int (-1) (f 0 (Error 1))
 
-type ('a, 'b) result_res = ('a, 'b) Result.result [@@deriving fold]
+type ('a, 'b) result_res = ('a, 'b) result [@@deriving fold]
 
 let test_result_result ctxt =
   let f = fold_result_res (+) (-) in
-  assert_equal ~printer:string_of_int 1 (f 0 (Result.Ok 1));
-  assert_equal ~printer:string_of_int (-1) (f 0 (Result.Error 1))
+  assert_equal ~printer:string_of_int 1 (f 0 (Ok 1));
+  assert_equal ~printer:string_of_int (-1) (f 0 (Error 1))
 
 let suite = "Test deriving(fold)" >::: [
   "test_btree" >:: test_btree;

--- a/src_test/iter/test_deriving_iter.cppo.ml
+++ b/src_test/iter/test_deriving_iter.cppo.ml
@@ -56,13 +56,13 @@ type 'a btreer = Node of { lft: 'a btree; elt: 'a; rgt: 'a btree } | Leaf
 type 'a ty = 'a * int list
 [@@deriving iter]
 
-type 'a res0 = ('a, char) Result.result [@@deriving iter]
+type 'a res0 = ('a, char) result [@@deriving iter]
 
 let test_iter_res ctxt =
   let has_ok = ref false in
-  iter_res0 (fun _ -> has_ok := true) (Result.Ok "xxx");
+  iter_res0 (fun _ -> has_ok := true) (Ok "xxx");
   assert_bool "set ok" !has_ok;
-  iter_res0 (fun _ -> has_ok := false) (Result.Error 'c');
+  iter_res0 (fun _ -> has_ok := false) (Error 'c');
   assert_bool "set ok" !has_ok
 
 let suite = "Test deriving(iter)" >::: [

--- a/src_test/map/test_deriving_map.cppo.ml
+++ b/src_test/map/test_deriving_map.cppo.ml
@@ -150,10 +150,9 @@ let test_map_result ctxt =
   assert_equal ~printer (Ok 10) (f (Ok 9));
   assert_equal ~printer (Error true) (f (Error true))
 
-type 'a result_result0 = ('a, bool) Result.result [@@deriving show,map]
+type 'a result_result0 = ('a, bool) result [@@deriving show,map]
 
 let test_map_result_result ctxt =
-  let open Result in
   let f = map_result_result0 succ in
   let printer = show_result_result0 fmt_int in
   assert_equal ~printer (Ok 10) (f (Ok 9));

--- a/src_test/ord/test_deriving_ord.cppo.ml
+++ b/src_test/ord/test_deriving_ord.cppo.ml
@@ -106,8 +106,7 @@ let test_ord_result ctx =
   assert_equal ~printer 1 (compare_res0 (Error ()) (Ok ()))
 
 let test_ord_result_result ctx =
-  let compare_res0 = [%ord: (unit, unit) Result.result] in
-  let open Result in
+  let compare_res0 = [%ord: (unit, unit) result] in
   assert_equal ~printer 0 (compare_res0 (Ok ()) (Ok ()));
   assert_equal ~printer (-1) (compare_res0 (Ok ()) (Error ()));
   assert_equal ~printer 1 (compare_res0 (Error ()) (Ok ()))

--- a/src_test/runtime/test_runtime.cppo.ml
+++ b/src_test/runtime/test_runtime.cppo.ml
@@ -19,21 +19,21 @@ let test_hashtbl
   (x : ('a, 'b) Ppx_deriving_runtime.Hashtbl.t)
 
 let test_result_qualified
-  (x : ('a, 'b) Result.result)
+  (x : ('a, 'b) result)
   =
-  (x : ('a, 'b) Ppx_deriving_runtime.Result.t)
+  (x : ('a, 'b) result)
 
 #if OCAML_VERSION >= (4, 06, 0)
 let test_result_included
   (x : ('a, 'b) result)
   =
-  (x : ('a, 'b) Ppx_deriving_runtime.Result.t)
+  (x : ('a, 'b) result)
 #endif
 
 #if OCAML_VERSION >= (4, 07, 0)
 let test_result_in_stdlib
   (x : ('a, 'b) Stdlib.result)
   =
-  (x : ('a, 'b) Ppx_deriving_runtime.Result.t)
+  (x : ('a, 'b) result)
 #endif
 

--- a/src_test/show/test_deriving_show.cppo.ml
+++ b/src_test/show/test_deriving_show.cppo.ml
@@ -172,12 +172,11 @@ let test_result ctxt =
   assert_equal ~printer "(Test_deriving_show.I_has (Error \"err\"))"
     (show_i_has_result (I_has (Error "err")))
 
-type i_has_result_result = I_has of (bool, string) Result.result [@@deriving show]
+type i_has_result_result = I_has of (bool, string) result [@@deriving show]
 
 let test_result_result ctxt =
-  let open Result in
   assert_equal ~printer "(Ok 100)"
-    ([%show: (int, bool) result] (Result.Ok 100));
+    ([%show: (int, bool) result] (Ok 100));
   assert_equal ~printer "(Test_deriving_show.I_has (Ok true))"
     (show_i_has_result_result (I_has (Ok true)));
   assert_equal ~printer "(Test_deriving_show.I_has (Error \"err\"))"


### PR DESCRIPTION
- even though the `Result` module was only added in OCaml 4.08:
  - the type `{Pervasives,Stdlib}.result` has been added as far back as OCaml 4.03 
  - ppx_deriving's lower bound is OCaml 4.05, so it should be fine to remove this dependency