### PR TITLE
Reintroduce a Ppx_deriving_runtime Result module for compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 unreleased
 ----------
 
+* Fix the unintentional removal of `Ppx_deriving_runtime.Result` in #279
+  #282
+  (@NathanReb)
+
 6.0.0 (15/04/2024) (aborted, not on opam)
 ----------------------------
 

--- a/src/runtime/ppx_deriving_runtime.cppo.ml
+++ b/src/runtime/ppx_deriving_runtime.cppo.ml
@@ -24,6 +24,15 @@ module Stdlib = Stdlib
 
 include Stdlib
 
+module Result = struct
+  type ('a, 'b) t = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+  type ('a, 'b) result = ('a, 'b) t =
+    | Ok of 'a
+    | Error of 'b
+end
 #else
 module Pervasives = Pervasives
 module Stdlib = Pervasives
@@ -49,6 +58,15 @@ module Weak = Weak
 module Printf = Printf
 module Format = Format
 module Buffer = Buffer
+module Result = struct
+  type ('a, 'b) t = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+  type nonrec ('a, 'b) result = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+end
 module Option = struct
   type 'a t = 'a option
 

--- a/src/runtime/ppx_deriving_runtime.cppo.mli
+++ b/src/runtime/ppx_deriving_runtime.cppo.mli
@@ -28,6 +28,18 @@ include module type of struct
 end
 
 module Stdlib = Stdlib
+
+module Result : sig
+  type ('a, 'b) t = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+  (* we also expose Result.result for backward-compatibility
+     with the Result package! *)
+  type ('a, 'b) result = ('a, 'b) t =
+    | Ok of 'a
+    | Error of 'b
+end
 #else
 module Pervasives = Pervasives
 
@@ -58,6 +70,17 @@ module Weak = Weak
 module Printf = Printf
 module Format = Format
 module Buffer = Buffer
+
+module Result : sig
+  type ('a, 'b) t = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+  (* we also expose Result.result for backward-compatibility *)
+  type nonrec ('a, 'b) result = ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+end
 
 module Option : sig
   type 'a t = 'a option


### PR DESCRIPTION
When removing our unneeded dependency on the `result` compat package, we inadvertently remove the `Result` module in `Ppx_deriving_runtime` which broke its API.

This should fix the issue we ran into when attempting to [release 6.0.0](https://github.com/ocaml/opam-repository/pull/25675#issuecomment-2057097995).