### PR TITLE
Fix misplaced attribute warning

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -321,7 +321,7 @@ let sanitize ?(module_=Lident "Ppx_deriving_runtime") ?(quoter=create_quoter ())
     let attrs = [attr_warning [%expr "-A"]] in
     let modname = { txt = module_; loc } in
     Exp.open_ ~loc ~attrs
-      (Opn.mk ~loc ~attrs ~override:Override (Mod.ident ~loc ~attrs modname))
+      (Opn.mk ~loc ~attrs ~override:Override (Mod.ident ~loc modname))
       expr in
   let sanitized = Expansion_helpers.Quoter.sanitize quoter body in
   (* ppxlib quoter uses Recursive, ppx_deriving's used Nonrecursive - silence warning *)


### PR DESCRIPTION
This fixes #280, where OCaml 5.2's new warning about unused-attributes fires.

To test, I made this change locally, pinned ppx_deriving to my fork using opam, and followed the repro case in the linked issue. With this change, the build succeeds without an unused-attribute warning.