### PR TITLE
Fix the ordering of `make`'s arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+unreleased
+----------
+
+* Fix ordering of derived `make`'s arguments
+  #285
+  (@NathanReb)
+
 6.0.1 (17/04/2024)
 ------------------
 

--- a/src_plugins/make/ppx_deriving_make.ml
+++ b/src_plugins/make/ppx_deriving_make.ml
@@ -97,7 +97,9 @@ let str_of_record_type ~quoter ~loc labels =
       | None ->
         record fields
     in
-    List.fold_left (add_str_label_arg ~quoter ~loc) fn labels
+    (* The labels list must be reversed here so that the arguments are in the
+       same order as the record fields. *)
+    List.fold_left (add_str_label_arg ~quoter ~loc) fn (List.rev labels)
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
   let quoter = Ppx_deriving.create_quoter () in
@@ -156,7 +158,9 @@ let sig_of_record_type ~loc ~typ labels =
       | None when has_option -> Typ.arrow Label.nolabel (tconstr "unit" []) typ
       | None -> typ
     in
-    List.fold_left add_sig_label_arg typ labels
+    (* The labels list must be reversed here so that the arguments are in the
+       same order as the record fields. *)
+    List.fold_left add_sig_label_arg typ (List.rev labels)
 
 let sig_of_type ({ ptype_loc = loc } as type_decl) =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in

--- a/src_test/make/test_deriving_make.ml
+++ b/src_test/make/test_deriving_make.ml
@@ -64,6 +64,23 @@ end = struct
   [@@deriving show]
 end
 
+(* This module is here to test that the ordering of the arguments
+   match the order of the record fields declarations. *)
+module M2 : sig
+  type t =
+    { first : int
+    ; second : int
+    }
+
+  val make : first: int -> second: int -> t
+end = struct
+  type t =
+    { first : int
+    ; second : int
+    }
+  [@@deriving make]
+end
+
 let test_no_main ctxt =
   assert_equal ~printer:M.show_a
                { M.a1 = None; a2 = []; a3 = 42; a4s = 2, []; a5 = 1 }


### PR DESCRIPTION
I introduced a bug in `ppx_deriving.make` when working on #281 and inadvertently changed the ordering of the arguments of the generated function.

The test suite failed to pick it up because the signature was also generated with `[@@deriving make]` and the ordering was swapped in both the signature and structure derivers.

I added a module with a handwritten signature and a derived implementation so that this can't happen again in the future.