### PR TITLE
Adds [%derive.pp] expressions.

### DIFF
--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -341,8 +341,14 @@ let deriving: Deriving.t =
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
 
-(* custom extension such that "derive"-prefixed also works *)
-let derive_extension =
+(* custom extensions such that "derive"-prefixed also works *)
+let derive_pp_extension =
+  Extension.V3.declare "derive.pp" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt ->
+      let loc = Expansion_context.Extension.extension_point_loc ctxt in
+      Ppx_deriving.with_quoter (fun quoter typ ->
+        [%expr fun fmt -> [%e expr_of_typ quoter typ]]))
+let derive_show_extension =
   Extension.V3.declare "derive.show" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt ->
       let loc = Expansion_context.Extension.extension_point_loc ctxt in
@@ -351,4 +357,7 @@ let derive_extension =
 let derive_transformation =
   Driver.register_transformation
     deriver
-    ~rules:[Context_free.Rule.extension derive_extension]
+    ~rules:[
+      Context_free.Rule.extension derive_pp_extension;
+      Context_free.Rule.extension derive_show_extension;
+    ]

--- a/src_test/show/test_deriving_show.cppo.ml
+++ b/src_test/show/test_deriving_show.cppo.ml
@@ -182,6 +182,14 @@ let test_result_result ctxt =
   assert_equal ~printer "(Test_deriving_show.I_has (Error \"err\"))"
     (show_i_has_result_result (I_has (Error "err")))
 
+let test_expr_pp ctxt =
+  let buf = Buffer.create 16 in
+  Format.fprintf (Format.formatter_of_buffer buf) "- %a -@?" [%pp: int] 42;
+  assert_equal ~printer "- 42 -" (Buffer.contents buf)
+
+let test_expr_show ctxt =
+  assert_equal ~printer "42" ([%show: int] 42)
+
 type es =
   | ESBool of (bool [@nobuiltin])
   | ESString of (string [@nobuiltin])
@@ -267,6 +275,8 @@ let suite = "Test deriving(show)" >::: [
     "test_paths"           >:: test_paths_printer;
     "test_result"          >:: test_result;
     "test_result_result"   >:: test_result_result;
+    "test_expr_pp"         >:: test_expr_pp;
+    "test_expr_show"       >:: test_expr_show;
   ]
 
 let _ = run_test_tt_main suite


### PR DESCRIPTION
This makes it easier to pretty-print an intermediate structure with the pretty-printer in a way that properly respects indentation.