### PR TITLE
Adds introductory example (OCaml Examples Project)

### DIFF
--- a/src_examples/dune
+++ b/src_examples/dune
@@ -1,7 +1,13 @@
 (executable
  (name print_test)
- (preprocess (pps ppx_deriving.show)))
+ (preprocess (pps ppx_deriving.show))
+ (modules print_test))
+
+(executable
+ (name introduction)
+ (preprocess (pps ppx_deriving.enum ppx_deriving.show ppx_deriving.eq ppx_deriving.ord))
+ (modules introduction))
 
 (alias
  (name examples)
- (deps print_test.exe))
+ (deps print_test.exe introduction.exe))

--- a/src_examples/introduction.ml
+++ b/src_examples/introduction.ml
@@ -1,0 +1,45 @@
+(* ppx_deriving has several plugins, which we must name in our dune file. For
+   example, ppx_deriving.show, ppx_deriving.enum etc. *)
+
+(* ppx_deriving.show can create a printer for a type. *)
+type tree =
+  | Lf
+  | Br of tree * int * tree [@@deriving show]
+  (* Generates function show_tree *)
+
+let tr = Br (Lf, 1, Br (Lf, 4, Lf))
+
+let show () =
+  print_endline (show_tree tr)
+
+(* ppx_deriving.eq and ppx_deriving.ord can define custom equality. Here, some
+   extra data in a record is ignored with regard to equality and ordering by
+   giving custom functions for equality and comparison to one field. *) 
+type r =
+  {index : int;
+   extra : int [@equal fun _ _ -> true] [@compare fun _ _ -> 0]}
+   [@@deriving eq, ord]
+   (* Generates functions equal_r and compare_r *)
+
+let eq_ord () =
+  Printf.printf "Equal: %b\n" (equal_r {index = 5; extra = 0} {index = 5; extra = 1});
+  Printf.printf "Compare: %i\n" (compare_r {index = 5; extra = 0} {index = 6; extra = 1});
+  Printf.printf "Compare: %i\n" (compare_r {index = 5; extra = 0} {index = 5; extra = 1})
+
+(* ppx_deriving.enum gives an integer to each argument-less constructor of a datatype *)
+type colour = Blue | Green | Red | Pink [@value 100] | Orange [@@deriving enum, show]
+
+let enum () =
+  Printf.printf "Integers: ";
+  List.iter
+    (fun x -> Printf.printf "%i " (colour_to_enum x))
+    [Blue; Green; Red; Pink; Orange];
+  Printf.printf "\n";
+  Printf.printf "0 is %S\n" (show_colour (match colour_of_enum 2 with Some c -> c | _ -> assert false))
+
+let () =
+  match Sys.argv with
+  | [|_; "show"|] -> show ()
+  | [|_; "eq_ord"|] -> eq_ord ()
+  | [|_; "enum"|] -> enum ()
+  | _ -> Printf.eprintf "ppx_deriving example: unknown command line\n"


### PR DESCRIPTION
Hello!

This pull request add another example to ppx_deriving. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please do give any comments you have on this programme.

(The above is boilerplate. For ppx_deriving specifically, I did look today at making the excellent usage examples from the README into one or more editable source files, in addition to the new example I have supplied. But I note the authors consider ppx_deriving to be deprecated, so I have desisted from further effort.)