### PR TITLE
Add support for OCaml 5.4

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -349,7 +349,7 @@ let path_of_type_decl ~path type_decl =
   | Some { ptyp_desc = Ptyp_constr ({ txt = lid }, _) } ->
     begin match lid with
     | Lident _ -> []
-    | Ldot (lid, _) -> Ocaml_common.Longident.flatten lid
+    | Ldot (lid, _) -> Astlib.Longident.flatten lid
     | Lapply _ -> assert false
     end
   | _ -> path
@@ -608,13 +608,13 @@ let derive path pstr_loc item attributes fn arg =
           name,
           Options
             (options |> List.map (fun ({ txt }, expr) ->
-               String.concat "." (Ocaml_common.Longident.flatten txt), expr))
+               String.concat "." (Astlib.Longident.flatten txt), expr))
         | { pexp_desc = Pexp_apply ({ pexp_desc = Pexp_ident name }, _) } ->
           name, Unknown_syntax
         | { pexp_loc } ->
           raise_errorf ~loc:pexp_loc "Unrecognized [@@deriving] syntax"
       in
-      let name, loc = String.concat "_" (Ocaml_common.Longident.flatten name.txt), name.loc in
+      let name, loc = String.concat "_" (Astlib.Longident.flatten name.txt), name.loc in
       let is_optional, options =
         match options with
         | Unknown_syntax -> false, options


### PR DESCRIPTION
Fixes the following error:
```
#=== ERROR while compiling ppx_deriving.6.1.0 =================================#
# context              2.4.0~alpha2 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/ppx_deriving.6.1.0
# command              ~/.opam/5.4/bin/dune build -p ppx_deriving -j 1
# exit-code            1
# env-file             ~/.opam/log/ppx_deriving-14-63972d.env
# output-file          ~/.opam/log/ppx_deriving-14-63972d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlopt.opt -w -40 -w -27-9 -g -I src/api/.ppx_deriving_api.objs/byte -I src/api/.ppx_deriving_api.objs/native -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ppx_derivers -I /home/opam/.opam/5.4/lib/ppxlib -I /home/opam/.opam/5.4/lib/ppxlib/ast -I /home/opam/.opam/5.4/lib/ppxlib/astlib -I /home/opam/.opam/5.4/lib/ppxlib/print_diff -I /home/opam/.opam/5.4/lib/ppxlib/stdppx -I /home/opam/.opam/5.4/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4/lib/sexplib0 -I /home/opam/.opam/5.4/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/api/.ppx_deriving_api.objs/native/ppx_deriving.cmx -c -impl src/api/ppx_deriving.pp.ml)
# File "ppx_deriving.cppo.ml", line 352, characters 54-57:
# Error: The value lid has type Ppxlib.longident = Astlib.Longident.t
#        but an expression was expected of type
#          Ocaml_common.Longident.t = Longident.t
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -bin-annot-occurrences -I src/api/.ppx_deriving_api.objs/byte -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.4/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.4/lib/ocaml/compiler-libs -I /home/opam/.opam/5.4/lib/ppx_derivers -I /home/opam/.opam/5.4/lib/ppxlib -I /home/opam/.opam/5.4/lib/ppxlib/ast -I /home/opam/.opam/5.4/lib/ppxlib/astlib -I /home/opam/.opam/5.4/lib/ppxlib/print_diff -I /home/opam/.opam/5.4/lib/ppxlib/stdppx -I /home/opam/.opam/5.4/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.4/lib/sexplib0 -I /home/opam/.opam/5.4/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/api/.ppx_deriving_api.objs/byte/ppx_deriving.cmo -c -impl src/api/ppx_deriving.pp.ml)
# File "ppx_deriving.cppo.ml", line 352, characters 54-57:
# Error: The value lid has type Ppxlib.longident = Astlib.Longident.t
#        but an expression was expected of type
#          Ocaml_common.Longident.t = Longident.t
```