### PR TITLE
Fix ord incorrectly quoting polymorphic comparison for builtins

### DIFF
--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -77,8 +77,7 @@ and expr_of_typ quoter typ =
               | [%type: int64] | [%type: Int64.t] | [%type: nativeint]
               | [%type: Nativeint.t] | [%type: float] | [%type: bool]
               | [%type: char] | [%type: string] | [%type: bytes]) ->
-        let compare_fn = [%expr fun (a:[%t typ]) b -> Ppx_deriving_runtime.compare a b] in
-        Ppx_deriving.quote ~quoter compare_fn
+        [%expr fun (a:[%t typ]) b -> Ppx_deriving_runtime.compare a b]
       | true, [%type: [%t? typ] ref] ->
         [%expr fun a b -> [%e expr_of_typ typ] !a !b]
       | true, [%type: [%t? typ] list]  ->

--- a/src_test/eq/test_deriving_eq.cppo.ml
+++ b/src_test/eq/test_deriving_eq.cppo.ml
@@ -110,11 +110,15 @@ and string =
 
 let test_std_shadowing ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in
+  let e1' = ESBool (Bfoo (1, (+) 2)) in
   let e2 = ESString (Sfoo ("lalala", (+) 3)) in
+  let e2' = ESString (Sfoo ("lalala", (+) 4)) in
   assert_equal ~printer false (equal_es e1 e2);
   assert_equal ~printer false (equal_es e2 e1);
   assert_equal ~printer true (equal_es e1 e1);
-  assert_equal ~printer true (equal_es e2 e2)
+  assert_equal ~printer true (equal_es e2 e2);
+  assert_equal ~printer true (equal_es e1 e1');
+  assert_equal ~printer true (equal_es e2 e2')
 
 type poly_app = float poly_abs
 and 'a poly_abs = 'a

--- a/src_test/ord/test_deriving_ord.cppo.ml
+++ b/src_test/ord/test_deriving_ord.cppo.ml
@@ -135,11 +135,15 @@ and string =
 
 let test_std_shadowing ctxt =
   let e1 = ESBool (Bfoo (1, (+) 1)) in
+  let e1' = ESBool (Bfoo (1, (+) 2)) in
   let e2 = ESString (Sfoo ("lalala", (+) 3)) in
+  let e2' = ESString (Sfoo ("lalala", (+) 4)) in
   assert_equal ~printer (-1) (compare_es e1 e2);
   assert_equal ~printer (1) (compare_es e2 e1);
   assert_equal ~printer 0 (compare_es e1 e1);
-  assert_equal ~printer 0 (compare_es e2 e2)
+  assert_equal ~printer 0 (compare_es e2 e2);
+  assert_equal ~printer 0 (compare_es e1 e1');
+  assert_equal ~printer 0 (compare_es e2 e2')
 
 type poly_app = float poly_abs
 and 'a poly_abs = 'a

--- a/src_test/ord/test_deriving_ord.cppo.ml
+++ b/src_test/ord/test_deriving_ord.cppo.ml
@@ -125,8 +125,8 @@ let test_ref2 ctxt =
   assert_equal ~printer (1) (compare_r2 (ref 1) (ref 0))
 
 type es =
-  | ESBool of bool
-  | ESString of string
+  | ESBool of (bool [@nobuiltin])
+  | ESString of (string [@nobuiltin])
 and bool =
   | Bfoo of int * ((int -> int) [@compare fun _ _ -> 0])
 and string =


### PR DESCRIPTION
While inspecting generated code for https://github.com/ocaml/ocaml/issues/14876#issuecomment-4816177881, I noticed something odd: ord is quoting builtins, but eq is not.

The history goes back and forth here.
The quoting was added by #115, which really was trying to fix monomorphization.
Previously, 71cabc00edb48616819ff43517bffc1a3d902552, trying to simplify, removed the monomorphization, which used to be there but without the quoting.
The only reason #115 added the quoting was to get the ord tests to build, but the problem wasn't the lack of quoting but the lack of `[@nobuiltin]` which the corresponding eq test uses.

Although #115 got the ord test to build by adding the quoting, the generated code was subtly wrong. When the "monomorphized" builtin comparison is lifted up by the quoter, the polymorphic comparison is actually applied to the redefined `bool` type, not the standard `bool`. So no monomorphization could actually take place.
Moreover, by performing polymorphic comparison on the redefined type, it completely bypasses the derived `compare_bool`. Since the redefined `bool` type contains a function, polymorphic comparison doesn't even work (i.e., crashes at runtime).