### PR TITLE
Use `Ppxlib.really_recursive` for plugin implementations

### DIFF
--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -194,12 +194,13 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
          (Pat.constraint_ eq_var out_type)
          (Ppx_deriving.sanitize ~quoter (eta_expand (polymorphize comparator)))]
 
-let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (rec_flag, type_decls) ->
   let str_of_type type_decl =
     Ast_helper.with_default_loc type_decl.ptype_loc @@
       fun () -> str_of_type type_decl
   in
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =

--- a/src_plugins/fold/ppx_deriving_fold.ml
+++ b/src_plugins/fold/ppx_deriving_fold.ml
@@ -134,8 +134,9 @@ let sig_of_type type_decl =
   [Sig.value ~loc (Val.mk (mkloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl) loc)
               (polymorphize [%type: [%t acc] -> [%t typ] -> [%t acc]]))]
 
-let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (rec_flag, type_decls) ->
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -127,12 +127,13 @@ let sig_of_type type_decl =
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl))
               (polymorphize [%type: [%t typ] -> Ppx_deriving_runtime.unit]))]
 
-let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (rec_flag, type_decls) ->
   let str_of_type type_decl =
     Ast_helper.with_default_loc type_decl.ptype_loc @@
       fun () -> str_of_type type_decl
   in
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =

--- a/src_plugins/map/ppx_deriving_map.ml
+++ b/src_plugins/map/ppx_deriving_map.ml
@@ -133,8 +133,9 @@ let sig_of_type type_decl =
   let typ = List.fold_right arrow poly_fns (arrow typ_arg typ_ret) in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix deriver) type_decl)) typ)]
 
-let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (rec_flag, type_decls) ->
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -230,12 +230,13 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
          (Pat.constraint_ out_var out_type)
          (Ppx_deriving.sanitize ~quoter (eta_expand (polymorphize comparator)))]
 
-let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
+let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (rec_flag, type_decls) ->
   let str_of_type type_decl =
     Ast_helper.with_default_loc type_decl.ptype_loc @@
       fun () -> str_of_type type_decl
   in
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -299,14 +299,14 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
   let show_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "show") type_decl) in
   let no_warn_32 = Ppx_deriving.attr_warning [%expr "-32"] in
-  [Vb.mk (Pat.constraint_ pp_var pp_type)
-         (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter));
-   Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter);]
+  (Vb.mk (Pat.constraint_ pp_var pp_type)
+         (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter)),
+   Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter))
 
 let impl_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
 (* TODO: add arg_default to ppxlib? *)
 
-let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (_, type_decls) with_path ->
+let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (rec_flag, type_decls) with_path ->
   let path =
     let code_path = Expansion_context.Deriver.code_path ctxt in
     (* Cannot use main_module_name from code_path because that contains .cppo suffix (via line directives), so it's actually not the module name. *)
@@ -332,8 +332,10 @@ let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (_, type_de
     Ast_helper.with_default_loc type_decl.ptype_loc @@
       fun () -> str_of_type ~with_path ~path type_decl
   in
-  (* TODO: use really_recursive; needs splitting pp and show to different value definitions *)
-  [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
+  let (pps, shows) = List.split (List.map str_of_type type_decls) in
+  let rec_flag = really_recursive rec_flag type_decls in
+  [Str.value rec_flag pps;
+   Str.value Nonrecursive shows])
 
 let intf_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
 

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -332,6 +332,7 @@ let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (_, type_de
     Ast_helper.with_default_loc type_decl.ptype_loc @@
       fun () -> str_of_type ~with_path ~path type_decl
   in
+  (* TODO: use really_recursive; needs splitting pp and show to different value definitions *)
   [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
 let intf_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -299,7 +299,8 @@ let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
   let show_var =
     pvar (Ppx_deriving.mangle_type_decl (`Prefix "show") type_decl) in
   let no_warn_32 = Ppx_deriving.attr_warning [%expr "-32"] in
-  (Vb.mk (Pat.constraint_ pp_var pp_type)
+  (Vb.mk ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]]
+         (Pat.constraint_ pp_var pp_type)
          (Ppx_deriving.sanitize ~quoter (polymorphize prettyprinter)),
    Vb.mk ~attrs:[no_warn_32] (Pat.constraint_ show_var show_type) (polymorphize stringprinter))
 


### PR DESCRIPTION
Currently the implementations are always recursive.
This can be inefficient because recursive functions are compiled differently: https://github.com/ocaml/ocaml/issues/14876#issuecomment-4825973808.

Various Jane Street ppx-s have been doing this for a long time, I guess that's why the function is in ppxlib to begin with.

The subtlety of this approach is that it uses the real recursiveness of the _type declaration_ to choose the recursiveness of the derived value definition. These should match in most cases, although technically this may break some weird uses, e.g. where the type is non-recursive but for whatever reason a deriver override attribute wants to do a recursive call.

### TODO
- [x] Benchmark with Goblint (together with https://github.com/sim642/ppx_deriving_hash/pull/8): No difference on OCaml 4.14, maybe 1% CPU time improvement on OCaml 5.6.0+trunk.