### PR TITLE
Remove now-unnecessary unused-rec-flag suppression from `sanitize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased
   #306
   (@sim642)
 
+* Remove now-unnecessary unused-rec-flag suppression from `sanitize`
+  #311
+  (@sim642)
+
 * Remove unnecessary cppo usage
   #308, #309
   (@sim642)

--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -331,9 +331,7 @@ let sanitize ?(module_=Lident "Ppx_deriving_runtime") ?(quoter=create_quoter ())
     Exp.open_ ~loc ~attrs
       (Opn.mk ~loc ~attrs ~override:Override (Mod.ident ~loc ~attrs modname))
       expr in
-  let sanitized = Expansion_helpers.Quoter.sanitize quoter body in
-  (* ppxlib quoter uses Recursive, ppx_deriving's used Nonrecursive - silence warning *)
-  { sanitized with pexp_attributes = attr_warning [%expr "-39"] :: sanitized.pexp_attributes}
+  Expansion_helpers.Quoter.sanitize quoter body
 
 let with_quoter fn a =
   let quoter = create_quoter () in


### PR DESCRIPTION
This was added in PR #263.
Ppxlib was changed to also return `Nonrecursive` bindings in https://github.com/ocaml-ppx/ppxlib/pull/401, making the warning suppression unnecessary. It was changed in ppxlib 0.30.0, but the current lower bound here is 0.36.0.

Individual plugins still add the suppression to the outer binding themselves.