### PR TITLE
Wrap deriver extensions in `with_default_loc`

### DIFF
--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -218,7 +218,7 @@ let deriving: Deriving.t =
 let derive_extension =
   Extension.V3.declare "derive.eq" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt typ ->
-      Ast_helper.with_default_loc typ.ptyp_loc @@
+      Ast_helper.with_default_loc {typ.ptyp_loc with loc_ghost = true} @@
         fun () -> Ppx_deriving.with_quoter expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation

--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -217,7 +217,9 @@ let deriving: Deriving.t =
 (* custom extension such that "derive"-prefixed also works *)
 let derive_extension =
   Extension.V3.declare "derive.eq" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> Ppx_deriving.with_quoter expr_of_typ)
+    Ast_pattern.(ptyp __) (fun ~ctxt typ ->
+      Ast_helper.with_default_loc typ.ptyp_loc @@
+        fun () -> Ppx_deriving.with_quoter expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation
     deriver

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -253,7 +253,9 @@ let deriving: Deriving.t =
 (* custom extension such that "derive"-prefixed also works *)
 let derive_extension =
   Extension.V3.declare "derive.ord" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> Ppx_deriving.with_quoter expr_of_typ)
+    Ast_pattern.(ptyp __) (fun ~ctxt typ ->
+      Ast_helper.with_default_loc typ.ptyp_loc @@
+        fun () -> Ppx_deriving.with_quoter expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation
     deriver

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -254,7 +254,7 @@ let deriving: Deriving.t =
 let derive_extension =
   Extension.V3.declare "derive.ord" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt typ ->
-      Ast_helper.with_default_loc typ.ptyp_loc @@
+      Ast_helper.with_default_loc {typ.ptyp_loc with loc_ghost = true} @@
         fun () -> Ppx_deriving.with_quoter expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -349,13 +349,16 @@ let deriving: Deriving.t =
     ~str_type_decl:impl_generator
     ~sig_type_decl:intf_generator
 
+let show_expr_of_typ quoter typ =
+  let loc = !Ast_helper.default_loc in
+  [%expr fun x -> Ppx_deriving_runtime.Format.asprintf "%a" (fun fmt -> [%e expr_of_typ quoter typ]) x]
+
 (* custom extension such that "derive"-prefixed also works *)
 let derive_extension =
   Extension.V3.declare "derive.show" Extension.Context.expression
-    Ast_pattern.(ptyp __) (fun ~ctxt ->
-      let loc = Expansion_context.Extension.extension_point_loc ctxt in
-      Ppx_deriving.with_quoter (fun quoter typ ->
-        [%expr fun x -> Ppx_deriving_runtime.Format.asprintf "%a" (fun fmt -> [%e expr_of_typ quoter typ]) x]))
+    Ast_pattern.(ptyp __) (fun ~ctxt typ ->
+      Ast_helper.with_default_loc typ.ptyp_loc @@
+        fun () -> Ppx_deriving.with_quoter show_expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation
     deriver

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -357,7 +357,7 @@ let show_expr_of_typ quoter typ =
 let derive_extension =
   Extension.V3.declare "derive.show" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt typ ->
-      Ast_helper.with_default_loc typ.ptyp_loc @@
+      Ast_helper.with_default_loc {typ.ptyp_loc with loc_ghost = true} @@
         fun () -> Ppx_deriving.with_quoter show_expr_of_typ typ)
 let derive_transformation =
   Driver.register_transformation


### PR DESCRIPTION
This was done for usual derivers in PR #297, but not for their extension node versions. These also use the quoter, which otherwise has no location.