### PR TITLE
src_plugins: mark default location as loc_ghost

### DIFF
--- a/src_plugins/create/ppx_deriving_create.ml
+++ b/src_plugins/create/ppx_deriving_create.ml
@@ -121,14 +121,14 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
 
 let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type type_decl
   in
   [Str.value Nonrecursive (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -196,14 +196,14 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
 
 let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type type_decl
   in
   [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -129,14 +129,14 @@ let sig_of_type type_decl =
 
 let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type type_decl
   in
   [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/make/ppx_deriving_make.ml
+++ b/src_plugins/make/ppx_deriving_make.ml
@@ -196,7 +196,7 @@ let partition_result l =
 
 let impl_generator =
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type type_decl
   in
   Deriving.Generator.V2.make_noarg (fun ~ctxt (_, type_decls) ->
@@ -209,7 +209,7 @@ let impl_generator =
 
 let intf_generator =
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   Deriving.Generator.V2.make_noarg (fun ~ctxt (_, type_decls) ->

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -232,14 +232,14 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
 
 let impl_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type type_decl
   in
   [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
 
 let intf_generator = Deriving.Generator.V2.make_noarg (fun ~ctxt:_ (_, type_decls) ->
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   List.concat (List.map sig_of_type type_decls))

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -329,7 +329,7 @@ let impl_generator = Deriving.Generator.V2.make impl_args (fun ~ctxt (_, type_de
     | None -> true (* true by default *)
   in
   let str_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> str_of_type ~with_path ~path type_decl
   in
   [Str.value Recursive (List.concat (List.map str_of_type type_decls))])
@@ -338,7 +338,7 @@ let intf_args = Deriving.Args.(empty +> arg "with_path" (Ast_pattern.ebool __))
 
 let intf_generator = Deriving.Generator.V2.make intf_args (fun ~ctxt:_ (_, type_decls) _with_path ->
   let sig_of_type type_decl =
-    Ast_helper.with_default_loc type_decl.ptype_loc @@
+    Ast_helper.with_default_loc {type_decl.ptype_loc with loc_ghost = true} @@
       fun () -> sig_of_type type_decl
   in
   List.concat (List.map sig_of_type type_decls))


### PR DESCRIPTION
Following https://github.com/ocaml-ppx/ppx_deriving/pull/297, some generated code now have proper locations attached by using the type_decl's location by default instead of a dummy one. However, because the location is used as-is, the generated code is indistinguishable from user code.
This leads to false positives in the dead_code_analyzer (https://github.com/LexiFi/dead_code_analyzer/pull/87).

According to [`Location`'s documentation](https://ocaml.org/manual/5.5/api/compilerlibref/Location.html#TYPEt),
> loc_ghost=false whenever the AST described by the location can be parsed from the location. In all other cases, loc_ghost must be true.
> Most locations produced by the parser have loc_ghost=false.
> When loc_ghost=true, the location is usually a best effort approximation.

The dead_code_analyzer actually relies on this property to decide if an element (value, method, ...) should be tracked or not.

Marking the generated code's default location with `loc_ghost=true` fixes the false positives without breaking the expected merlin behavior mentioned in https://github.com/ocaml-ppx/ppx_deriving/pull/297.