### PR TITLE
fix the double printing of locations in submessages

### DIFF
--- a/src/api/ppx_deriving.cppo.ml
+++ b/src/api/ppx_deriving.cppo.ml
@@ -171,21 +171,26 @@ let lookup name =
 let raise_errorf ?sub ?loc fmt =
   let module Location = Ocaml_common.Location in
   let raise_msg str =
-    let sub =
-      let msg_of_error err =
 #if OCAML_VERSION >= (5, 3, 0)
-        let loc = err.Location.main.loc in
-        let print_report fmt x =
-          Ocaml_common.Format_doc.deprecated_printer
-            (fun fmt -> Location.print_report fmt x) fmt
-        in
-        Location.msg ~loc "%a" print_report err
+    let collect_subs err acc =
+      err.Location.main ::
+      err.Location.sub @
+      match err.Location.footnote with
+      | None -> acc
+      | Some doc -> Location.mknoloc doc :: acc
+    in
+    let sub = Option.map (fun sub -> List.fold_right collect_subs sub []) sub in
 #else
-        { txt = (fun fmt -> Location.print_report fmt err);
-          loc = err.Location.main.loc }
-#endif
+    let msg_of_error err =
+      let msg fmt =
+        let printer = !Location.report_printer () in
+        printer.pp_main_txt printer err fmt err.Location.main.txt;
+        printer.pp_submsgs printer err fmt err.Location.sub;
       in
-      Option.map (List.map msg_of_error) sub in
+      { txt = msg; loc = err.Location.main.loc }
+    in
+    let sub = Option.map (List.map msg_of_error) sub in
+#endif
     let err = Location.error ?sub ?loc str in
     raise (Location.Error err) in
   Printf.ksprintf raise_msg fmt


### PR DESCRIPTION
fixes #310

Explanations from https://github.com/ocaml-ppx/ppx_deriving/pull/314#issuecomment-5048652613 where this fix first appeared:

> Thanks to the hints of @sim642 in [#310 (comment)](https://github.com/ocaml-ppx/ppx_deriving/issues/310#issuecomment-5044539495), I could understand the issue with the double-printing of locations in submessages. The issue comes from a mismatch of expectations between our API for submessages (which is not great) and the API of Location in the compiler for submessages (which is not great, but different).
> 
> The Location API expects a submessage that does not print its own location (it helpfully takes care of this), but we used the convenience function `Location.print_report` to create the submessage, which does print its own location, and so locations were printed twice.
> 
> The fix is slightly different before and after 5.3.0 but it is basically the same idea. The >=5.3.0 fix drops the "footnote" information (which is new in the Location datatype) because I timed out before finding a convenient way to print it, but I thought that it would be an acceptable tradeoff for now (it is _probably_ the case that no one uses it for now anyway, certainly not builtin derivers).

