### PR TITLE
Mark more locations as `loc_ghost`

### DIFF
--- a/src_plugins/create/ppx_deriving_create.ml
+++ b/src_plugins/create/ppx_deriving_create.ml
@@ -35,6 +35,7 @@ let find_main labels =
     (None, []) labels
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let quoter = Ppx_deriving.create_quoter () in
   let creator =
     match type_decl.ptype_kind with
@@ -50,7 +51,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
         | None ->
           Exp.fun_ Label.nolabel None (punit ()) (record fields)
       in
-      List.fold_left (fun accum ({ pld_name = { txt = name }; pld_type; pld_attributes } as label) ->
+      List.fold_left (fun accum ({ pld_name = { txt = name }; pld_type; pld_attributes } as label) -> (* TODO: use loc of label name like in sig_of_type? *)
         match get_label_attribute attr_default label with
         | Some default -> Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
                                    (pvar name) accum
@@ -82,6 +83,7 @@ let wrap_predef_option typ =
   typ
 
 let sig_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let typ =
     match type_decl.ptype_kind with
@@ -95,6 +97,7 @@ let sig_of_type ({ ptype_loc = loc } as type_decl) =
           Typ.arrow Label.nolabel (tconstr "unit" []) typ
       in
       List.fold_left (fun accum ({ pld_name = { txt = name; loc }; pld_type; pld_attributes } as label) ->
+        let loc = {loc with loc_ghost = true} in
         match get_label_attribute attr_default label with
         | Some _ -> Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum
         | None ->

--- a/src_plugins/enum/ppx_deriving_enum.ml
+++ b/src_plugins/enum/ppx_deriving_enum.ml
@@ -60,7 +60,7 @@ let mappings_of_type type_decl =
       let sigil = match kind with `Regular -> "" | `Polymorphic -> "`" in
       let sub =
         [Ocaml_common.Location.errorf
-          ~loc:bloc "Same as for %s%s" sigil btxt] in
+          ~loc:bloc "Same as for %s%s" sigil btxt] in (* NB! do not use loc_ghost for submessage because newer compilers will hide it *)
       raise_errorf ~sub ~loc:aloc
                    "%s: duplicate value %d for constructor %s%s" deriver a sigil atxt
     | _ :: rest -> check_dup rest
@@ -69,7 +69,7 @@ let mappings_of_type type_decl =
   mappings |> List.stable_sort (fun (a,_) (b,_) -> compare a b) |> check_dup;
   kind, mappings
 
-let str_of_type ({ ptype_loc = loc } as type_decl) =
+let str_of_type ({ ptype_loc = _ } as type_decl) =
   let kind, mappings = mappings_of_type type_decl in
   let patt name =
     match kind with
@@ -98,7 +98,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
          (Exp.function_ from_enum_cases)]
 
 let sig_of_type type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   [Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "min") type_decl))
              [%type: Ppx_deriving_runtime.int]);

--- a/src_plugins/eq/ppx_deriving_eq.ml
+++ b/src_plugins/eq/ppx_deriving_eq.ml
@@ -45,7 +45,7 @@ let rec exprn quoter typs =
 
 and exprl quoter typs =
   typs |> List.map (fun ({ pld_name = { txt = n }; pld_loc; _ } as pld) ->
-    with_default_loc pld_loc @@ fun () ->
+    with_default_loc {pld_loc with loc_ghost = true} @@ fun () ->
     app (expr_of_label_decl quoter pld)
       [evar (argl `lhs n); evar (argl `rhs n)])
 
@@ -139,6 +139,7 @@ and expr_of_typ quoter typ =
                    deriver (Ppx_deriving.string_of_core_type typ)
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let quoter = Ppx_deriving.create_quoter () in
   let comparator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
@@ -146,7 +147,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
     | Ptype_variant constrs, _ ->
       let cases =
         (constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_loc } ->
-          with_default_loc pcd_loc @@ fun () ->
+          with_default_loc {pcd_loc with loc_ghost = true} @@ fun () ->
           match pcd_args with
           | Pcstr_tuple(typs) ->
             exprn quoter typs |>
@@ -165,7 +166,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
     | Ptype_record labels, _ ->
       let exprs =
         labels |> List.map (fun ({ pld_loc; pld_name = { txt = name }; _ } as pld) ->
-          with_default_loc pld_loc @@ fun () ->
+          with_default_loc {pld_loc with loc_ghost = true} @@ fun () ->
           (* combine attributes of type and label *)
           let field obj = Exp.field obj (mknoloc (Lident name)) in
           app (expr_of_label_decl quoter pld)

--- a/src_plugins/fold/ppx_deriving_fold.ml
+++ b/src_plugins/fold/ppx_deriving_fold.ml
@@ -22,7 +22,7 @@ let reduce_acc a b =
   [%expr let acc = [%e a] in [%e b]]
 
 let rec expr_of_typ typ =
-  let loc = typ.ptyp_loc in
+  let loc = {typ.ptyp_loc with loc_ghost = true} in
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun acc _ -> acc]
@@ -84,6 +84,7 @@ and expr_of_label_decl { pld_type; pld_attributes } =
   expr_of_typ { pld_type with ptyp_attributes = attrs }
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let mapper =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest -> expr_of_typ manifest
@@ -122,7 +123,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
          (polymorphize mapper)]
 
 let sig_of_type type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let vars =
     (List.map (fun tyvar -> tyvar.txt))

--- a/src_plugins/iter/ppx_deriving_iter.ml
+++ b/src_plugins/iter/ppx_deriving_iter.ml
@@ -80,6 +80,7 @@ and expr_of_label_decl { pld_type; pld_attributes } =
   expr_of_typ { pld_type with ptyp_attributes = attrs }
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let iterator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest -> expr_of_typ manifest

--- a/src_plugins/make/ppx_deriving_make.ml
+++ b/src_plugins/make/ppx_deriving_make.ml
@@ -53,6 +53,7 @@ let is_optional ({ pld_name = { txt = name }; pld_type; _ } as label) =
 
 let add_str_label_arg ~quoter ~loc accum
     ({pld_name = {txt = name}; pld_type; _} as label) =
+  let loc = {loc with loc_ghost = true} in
   match get_label_attribute attr_default label with
   | Some default ->
     Exp.fun_ (Label.optional name) (Some (Ppx_deriving.quote ~quoter default))
@@ -118,7 +119,8 @@ let wrap_predef_option typ =
   typ
 
 let add_sig_label_arg accum
-    ({pld_name = {txt = name; loc}; pld_type; _} as label) = 
+    ({pld_name = {txt = name; loc}; pld_type; _} as label) =
+  let loc = {loc with loc_ghost = true} in
   match get_label_attribute attr_default label with
   | Some _ ->
     Typ.arrow (Label.optional name) (wrap_predef_option pld_type) accum

--- a/src_plugins/map/ppx_deriving_map.ml
+++ b/src_plugins/map/ppx_deriving_map.ml
@@ -19,7 +19,7 @@ let pconstrrec name fields = pconstr name [precord ~closed:Closed fields]
 let  constrrec name fields =  constr name [ record                fields]
 
 let rec expr_of_typ ?decl typ =
-  let loc = typ.ptyp_loc in
+  let loc = {typ.ptyp_loc with loc_ghost = true} in
   let typ = Ppx_deriving.remove_pervasives ~deriver typ in
   match typ with
   | _ when Ppx_deriving.free_vars_in_core_type typ = [] -> [%expr fun x -> x]
@@ -86,6 +86,7 @@ and expr_of_label_decl ?decl { pld_type; pld_attributes } =
   expr_of_typ ?decl { pld_type with ptyp_attributes = attrs }
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let mapper =
     match type_decl.ptype_kind, type_decl.ptype_manifest with
     | Ptype_abstract, Some manifest -> expr_of_typ ~decl:type_decl manifest
@@ -124,7 +125,7 @@ let str_of_type ({ ptype_loc = loc } as type_decl) =
          (polymorphize mapper)]
 
 let sig_of_type type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ_arg, var_arg, bound = Ppx_deriving.instantiate []    type_decl in
   let typ_ret, var_ret, _     = Ppx_deriving.instantiate bound type_decl in
   let arrow = Typ.arrow Label.nolabel in

--- a/src_plugins/ord/ppx_deriving_ord.ml
+++ b/src_plugins/ord/ppx_deriving_ord.ml
@@ -58,7 +58,7 @@ and expr_of_label_decl quoter { pld_type; pld_attributes } =
   expr_of_typ quoter { pld_type with ptyp_attributes = attrs }
 
 and expr_of_typ quoter typ =
-  let loc = typ.ptyp_loc in
+  let loc = {typ.ptyp_loc with loc_ghost = true} in
   let expr_of_typ = expr_of_typ quoter in
   match Attribute.get ct_attr_compare typ with
   | Some fn -> Ppx_deriving.quote ~quoter fn
@@ -164,7 +164,7 @@ and expr_of_typ quoter typ =
                    deriver (Ppx_deriving.string_of_core_type typ)
 
 let core_type_of_decl type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
           (fun var -> [%type: [%t var] -> [%t var] -> Ppx_deriving_runtime.int]) type_decl in
@@ -175,6 +175,7 @@ let sig_of_type type_decl =
              (core_type_of_decl type_decl))]
 
 let str_of_type ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let quoter = Ppx_deriving.create_quoter () in
   let comparator =
     match type_decl.ptype_kind, type_decl.ptype_manifest with

--- a/src_plugins/show/ppx_deriving_show.ml
+++ b/src_plugins/show/ppx_deriving_show.ml
@@ -43,7 +43,7 @@ let wrap_printer quoter printer =
     [%expr (let fprintf = Ppx_deriving_runtime.Format.fprintf in [%e printer]) [@ocaml.warning "-26"]]
 
 let pp_type_of_decl type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   Ppx_deriving.poly_arrow_of_type_decl
     (fun var -> [%type: Ppx_deriving_runtime.Format.formatter -> [%t var] -> Ppx_deriving_runtime.unit])
@@ -51,7 +51,7 @@ let pp_type_of_decl type_decl =
     [%type: Ppx_deriving_runtime.Format.formatter -> [%t typ] -> Ppx_deriving_runtime.unit]
 
 let show_type_of_decl type_decl =
-  let loc = type_decl.ptype_loc in
+  let loc = {type_decl.ptype_loc with loc_ghost = true} in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   Ppx_deriving.poly_arrow_of_type_decl
     (fun var -> [%type: Ppx_deriving_runtime.Format.formatter -> [%t var] -> Ppx_deriving_runtime.unit])
@@ -65,7 +65,7 @@ let sig_of_type type_decl =
               (show_type_of_decl type_decl))]
 
 let rec expr_of_typ quoter typ =
-  let loc = typ.ptyp_loc in
+  let loc = {typ.ptyp_loc with loc_ghost = true} in
   let expr_of_typ = expr_of_typ quoter in
   match Attribute.get ct_attr_printer typ with
   | Some printer -> [%expr [%e wrap_printer quoter printer] fmt]
@@ -190,6 +190,7 @@ and expr_of_label_decl quoter { pld_type; pld_attributes } =
   expr_of_typ quoter { pld_type with ptyp_attributes = attrs }
 
 let str_of_type ~with_path ~path ({ ptype_loc = loc } as type_decl) =
+  let loc = {loc with loc_ghost = true} in
   let quoter = Ppx_deriving.create_quoter () in
   let path = Ppx_deriving.path_of_type_decl ~path type_decl in
   let prettyprinter =


### PR DESCRIPTION
This is a continuation of #313.
There are plenty of other places in the plugins which take a location from some subnode, rather than `default_loc`, and new nodes created with that location should also be `loc_ghost`.

In order to not go too crazy, I omitted this for the locations that are only used for `raise_errorf` because the semantics of `loc_ghost` on those exceptions isn't clear to me: they don't end up as locations of new `Parsetree` nodes.
The situation might be a bit more hazy for `extension_errorf` (which ppx_deriving doesn't use much): they do end up as `Parsetree` nodes, but they would always mean something ghost-like (except if the program literally contains `[@ocaml.error ...]` but that would be very strange).